### PR TITLE
[G3] 11437 LCA

### DIFF
--- a/week03/assignment02/11437_lca_joonparkhere.go
+++ b/week03/assignment02/11437_lca_joonparkhere.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bufio"
+	"math"
+	"os"
+	"strconv"
+)
+
+type Node struct {
+	depth int
+	adjacent []int
+}
+
+const (
+	maxNumOfVertex = 500000
+)
+
+var (
+	scanner = bufio.NewScanner(os.Stdin)
+	writer = bufio.NewWriter(os.Stdout)
+	numOfVertex int
+	log2NumOfVertex int
+	tree []Node
+	parent [][]int
+)
+
+func main() {
+	defer writer.Flush()
+	scanner.Split(bufio.ScanWords)
+
+	inputEdge()
+	findParentAndDepth()
+	findLCAVer2()
+}
+
+func scanInt() int {
+	scanner.Scan()
+	ret, _ := strconv.Atoi(scanner.Text())
+	return ret
+}
+
+func inputEdge() {
+	numOfVertex = scanInt()
+	log2NumOfVertex = int(math.Ceil(math.Log2(float64(numOfVertex))))
+
+	tree = make([]Node, numOfVertex + 1)
+	parent = make([][]int, numOfVertex + 1)
+	for i := range parent {
+		parent[i] = make([]int, log2NumOfVertex)
+		for j := range parent[i] {
+			parent[i][j] = -1
+		}
+	}
+
+	for i := 1; i < numOfVertex; i++ {
+		idxA, idxB := scanInt(), scanInt()
+		parent[idxA][0] = -1
+		parent[idxB][0] = -1
+		tree[idxA].adjacent = append(tree[idxA].adjacent, idxB)
+		tree[idxB].adjacent = append(tree[idxB].adjacent, idxA)
+	}
+}
+
+func findParentAndDepth() {
+	queue := make([]int, 0)
+
+	parent[1][0] = 0
+	tree[1].depth = 0
+	queue = append(queue, 1)
+
+	for len(queue) > 0 {
+		curIdx := queue[0]
+		queue = queue[1:]
+		for _, idx := range tree[curIdx].adjacent {
+			// idx 에 해당하는 Node 의 parent 가 -1 이면 아직 방문을 하지 않았고, 그렇지 않으면 전에 방문을 했다는 의미
+			if parent[idx][0] != -1 {
+				continue
+			}
+			parent[idx][0] = curIdx
+			tree[idx].depth = tree[curIdx].depth + 1
+			queue = append(queue, idx)
+		}
+	}
+}
+
+// 이전 풀이 방법
+func findLCAVer1() {
+	numOfCase := scanInt()
+	for i := 0; i < numOfCase; i++ {
+		idxA, idxB := scanInt(), scanInt()
+		depthA, depthB := tree[idxA].depth, tree[idxB].depth
+
+		for depthA != depthB {
+			if depthA < depthB {
+				idxB = parent[idxB][0]
+				depthB = tree[idxB].depth
+			} else {
+				idxA = parent[idxA][0]
+				depthA = tree[idxA].depth
+			}
+		}
+
+		for idxA != idxB {
+			idxA = parent[idxA][0]
+			idxB = parent[idxB][0]
+		}
+		writer.WriteString(strconv.Itoa(idxA) + "\n")
+	}
+}
+
+func findLCAVer2() {
+	findAllParent()
+
+	numOfCase := scanInt()
+	for i := 0; i < numOfCase; i++ {
+		idxA, idxB := scanInt(), scanInt()
+		if tree[idxA].depth < tree[idxB].depth {
+			idxA, idxB = idxB, idxA
+		}
+
+		depthA, depthB := tree[idxA].depth, tree[idxB].depth
+		gap := depthA - depthB
+
+		for cnt := int(math.Ceil(math.Log2(maxNumOfVertex))); cnt != -1; cnt-- {
+			if (gap & (1 << cnt)) != 0 {
+				idxA = parent[idxA][cnt]
+			}
+		}
+
+		if idxA != idxB {
+			for cnt := log2NumOfVertex - 1; cnt >= 0; cnt-- {
+				if (parent[idxA][cnt] != -1) && (parent[idxA][cnt] != parent[idxB][cnt]) {
+					idxA = parent[idxA][cnt]
+					idxB = parent[idxB][cnt]
+				}
+			}
+			idxA = parent[idxA][0]
+		}
+		writer.WriteString(strconv.Itoa(idxA) + "\n")
+	}
+}
+
+func findAllParent() {
+	// 한 노드가 가질 수 있는 모든 부모들의 최대 개수는 트리의 높이 (log2NumOfVertex) 라고 할 수 있다.
+	for cnt := 1; cnt < log2NumOfVertex; cnt++ {
+		for idx := 2; idx <= numOfVertex; idx++ {
+			if parent[idx][cnt - 1] == -1 {
+				continue
+			}
+			parent[idx][cnt] =  parent[parent[idx][cnt - 1]][cnt - 1]
+		}
+	}
+}


### PR DESCRIPTION
## 🍕 대략적인 풀이

- 트리가 주어질 때 한 쌍의 노드에 대해 공통 부모가 어느 것인지 알아내는 문제이다.
- 공통 부모 노드를 알아내야 하는 두 노드의 depth 가 만약 같다면 공통 부모를 찾는 것은 어렵지 않다. 반복문을 돌면서 계속해서 부모 index 에 접근하고 index 값이 같은지 확인하면 된다.
- 다만 두 노드의 depth 가 다르다면 더 깊은 depth 의 노드를 다른 노드의 depth 와 같을 때까지 parent index 에 접근하며 두 노드의 depth 를 맞춰 주어야 한다.
- 즉, 필요한 정보는 각 노드들의 depth 와 parent index 정보이다.
- 이후 성능 개선을 위해 Binary Search 형식으로 부모를 탐색할 수 있도록 로직을 수정했다.



## 🍿 소요 메모리, 시간

1. 첫 번째 시도: 12644KB, 1208ms

   - `findParentAndDepth()` 함수에서 BFS 를 이용해 모든 노드들을 방문하는데, 방문 여부를 저장하는 `isVisit []bool` 을 사용했다.

2. 두 번째 시도: 7504KB, 1168ms

   - `findParentAndDepth()` 함수에서 `isVisit []bool` 없이도 방문 여부를 확인할 수 있지 않을까 생각해봤다.
   - 초기에 각 노드의 `parent` 값을 -1 로 세팅해주면, BFS 를 할 때, 방문한 노드의 `parent` 값이 -1 인지 아닌지로 방문 여부를 확인할 수 있다.
   - 덕분에 메모리 사용량을 줄일 수 있었다.

3. 세 번째 시도: 13764KB, 1168ms

   - 소요 시간이 보다 짧은 다른 풀이들 중 일부가 DFS 로 노드들을 훑길래, 혹시 BFS 가 더 많이 반복해서 시간 소요가 큰 가 생각해서 `findParentAndDepth()`를 DFS 형태로 바꾸어 보았다.

     ```go
     func findParentAndDepth(current, parent, depth int) {
     	if tree[current].parent != -1 {
     		return
     	}
     	tree[current].parent = parent
     	tree[current].depth = depth
     	for _, idx := range tree[current].adjacent {
     		if idx == parent {
     			continue
     		}
     		findParentAndDepth(idx, current, depth + 1)
     	}
     }
     ```

   - 하지만 함수 호출이 많아지면서 메모리 소모가 증가했고, 반복 횟수는 비슷해서 소요 시간은 변함 없었다.

4. 네 번째 시도: 17440KB, 68ms

   - 가장 큰 변화는 각 노드의 부모, 부모의 부모, 부모의 부모의 부모 ... 등을 기록할 슬라이스를 추가 활용해서 두 노드의 공통 부모를 빠르게 탐색할 수 있도록 바꾸었다.

     원래는 depth 를 하나씩 줄여가며 부모를 탐색했다. 다음은 기존 로직의 코드이다.

     ```go
     func findLCAVer1() {
     	numOfCase := scanInt()
     	for i := 0; i < numOfCase; i++ {
     		idxA, idxB := scanInt(), scanInt()
     		depthA, depthB := tree[idxA].depth, tree[idxB].depth
     
     		for depthA != depthB {
     			if depthA < depthB {
     				idxB = parent[idxB][0]
     				depthB = tree[idxB].depth
     			} else {
     				idxA = parent[idxA][0]
     				depthA = tree[idxA].depth
     			}
     		}
     
     		for idxA != idxB {
     			idxA = parent[idxA][0]
     			idxB = parent[idxB][0]
     		}
     		writer.WriteString(strconv.Itoa(idxA) + "\n")
     	}
     }
     ```

     다음은 변경 후의 로직 코드이다.

     ```go
     func findLCAVer2() {
     	findAllParent()
     
     	numOfCase := scanInt()
     	for i := 0; i < numOfCase; i++ {
     		idxA, idxB := scanInt(), scanInt()
     		if tree[idxA].depth < tree[idxB].depth {
     			idxA, idxB = idxB, idxA
     		}
     
     		depthA, depthB := tree[idxA].depth, tree[idxB].depth
     		gap := depthA - depthB
     
     		for cnt := int(math.Ceil(math.Log2(maxNumOfVertex))); cnt != -1; cnt-- {
     			if (gap & (1 << cnt)) != 0 {
     				idxA = parent[idxA][cnt]
     			}
     		}
     
     		if idxA != idxB {
     			for cnt := log2NumOfVertex - 1; cnt >= 0; cnt-- {
     				if (parent[idxA][cnt] != -1) && (parent[idxA][cnt] != parent[idxB][cnt]) {
     					idxA = parent[idxA][cnt]
     					idxB = parent[idxB][cnt]
     				}
     			}
     			idxA = parent[idxA][0]
     		}
     		writer.WriteString(strconv.Itoa(idxA) + "\n")
     	}
     }
     
     func findAllParent() {
     	// 한 노드가 가질 수 있는 모든 부모들의 최대 개수는 트리의 높이 (log2NumOfVertex) 라고 할 수 있다.
     	for cnt := 1; cnt < log2NumOfVertex; cnt++ {
     		for idx := 2; idx <= numOfVertex; idx++ {
     			if parent[idx][cnt - 1] == -1 {
     				continue
     			}
     			parent[idx][cnt] =  parent[parent[idx][cnt - 1]][cnt - 1]
     		}
     	}
     }
     ```

   - `parent [][]int`를 사용했는데, 예를 들어 설명하면 `parent[10][0]`은 index 가 `10` 인 노드의 `2^0 = 1` 번 거슬러 올라갔을 때 부모를 의미한다. `parent[10][2]`은 index 가 `10`인 노드의 `2^2 = 4`번 거슬러 올라갔을 때 부모를 의미한다. 즉 `parent`를 이용해 부모를 Binary Search 를 하는 느낌이다.

   - 이 관계는 점화식 `parent[idx][cnt] = parent[ parent[idx][cnt-1] ][cnt]` 성질을 갖는다. 이를 이용해 노드의 모든 부모들을 기록할 수 있다. (코드의 `findAllParent()` 함수에서 사용)

   - 그리고 입력 받은 두 노드의 depth 가 다르면 차이 만큼 부모를 탐색한다.

     ```go
     for cnt := int(math.Ceil(math.Log2(maxNumOfVertex))); cnt != -1; cnt-- {
         if (gap & (1 << cnt)) != 0 {
             idxA = parent[idxA][cnt]
         }
     }
     ```

     - `math.Ceil(math.Log2(maxNumOfVertex)) = 19`는 가능한 최대 부모의 수이다.
     - 만약 `gap = 3 = 00...011` 이면 `cnt`가 `1`일 때와 `0`일 때 조건이 성립해서 노드의 `2^cnt`번 거슬러 올라갔을 때 부모를 탐색한다.

   - 이제 `cnt`를 가능한 큰 값 (즉, 트리의 높이 값) 부터 시작해서 `0`까지, 두 노드의 `parent[idx][cnt]` 가 다르면 각 노드의 `2^cnt`번 거슬러 올라갔을 때 부모를 탐색한다.

     ```go
     for cnt := log2NumOfVertex - 1; cnt >= 0; cnt-- {
         if (parent[idxA][cnt] != -1) && (parent[idxA][cnt] != parent[idxB][cnt]) {
             idxA = parent[idxA][cnt]
             idxB = parent[idxB][cnt]
         }
     }
     ```

     이 과정을 계속 반복하면 공통 부모를 찾을 수 있다.

