### PR TITLE
[G3] 2263 트리의 순회

### DIFF
--- a/week03/assignment03/2263_트리의 순회_joonparkhere.go
+++ b/week03/assignment03/2263_트리의 순회_joonparkhere.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+)
+
+var (
+	scanner     = bufio.NewScanner(os.Stdin)
+	writer      = bufio.NewWriter(os.Stdout)
+	numOfVertex int
+	inorder     []int
+	postorder   []int
+	cache map[int]int
+)
+
+func main() {
+	defer writer.Flush()
+	scanner.Split(bufio.ScanWords)
+
+	inputInorderAndPostorder()
+	//splitTreeVer1(0, 0, numOfVertex)
+	//splitTreeVer2(inorder, postorder)
+	processToCache()
+	splitTreeVer3(inorder, postorder, 0)
+}
+
+func inputInorderAndPostorder() {
+	numOfVertex = scanInt()
+	inorder = make([]int, numOfVertex)
+	for i := 0; i < numOfVertex; i++ {
+		inorder[i] = scanInt()
+	}
+	postorder = make([]int, numOfVertex)
+	for i := 0; i < numOfVertex; i++ {
+		postorder[i] = scanInt()
+	}
+}
+
+func scanInt() int {
+	scanner.Scan()
+	ret, _ := strconv.Atoi(scanner.Text())
+	return ret
+}
+
+func splitTreeVer1(beginIdxAtInorder, beginIdxAtPostorder, size int) {
+	if size == 1 {
+		writer.WriteString(strconv.Itoa(inorder[beginIdxAtInorder]) + " ")
+		return
+	}
+
+	// Post-order 의 시작 index 에 Sub Tree 크기를 더하고 1 을 빼면, 마지막 Post-order index 이다.
+	lastIdxAtPostorder := beginIdxAtPostorder + size - 1
+	root := postorder[lastIdxAtPostorder]
+	writer.WriteString(strconv.Itoa(root) + " ")
+
+	// 위에서 구한 root 가 In-order 에서는 어느 index 에 위치했는지 찾는다.
+	var splitIdxAtInorder int
+	for idx := beginIdxAtInorder; idx < numOfVertex; idx++ {
+		if inorder[idx] == root {
+			splitIdxAtInorder = idx
+			break
+		}
+	}
+
+	// In-order 에서의 root index 를 기점으로 앞부분과 뒷부분 Sub Tree 에 대해 재귀 함수 처리한다.
+	frontSplitSize := splitIdxAtInorder - beginIdxAtInorder
+	if frontSplitSize > 0 {
+		splitTreeVer1(beginIdxAtInorder, beginIdxAtPostorder, frontSplitSize)
+	}
+
+	backSplitSize := size - frontSplitSize - 1
+	if backSplitSize > 0 {
+		splitTreeVer1(splitIdxAtInorder + 1, beginIdxAtPostorder +frontSplitSize, backSplitSize)
+	}
+}
+
+func splitTreeVer2(subInorder, subPostorder []int) {
+	if len(subInorder) == 0 {
+		return
+	}
+
+	lastIdxAtSubPostorder := len(subPostorder)-1
+	root := subPostorder[lastIdxAtSubPostorder]
+	writer.WriteString(strconv.Itoa(root) + " ")
+
+	var splitIdx int
+	for idx, value := range subInorder {
+		if value == root {
+			splitIdx = idx
+			break
+		}
+	}
+
+	splitTreeVer2(subInorder[:splitIdx], subPostorder[:splitIdx])
+	splitTreeVer2(subInorder[splitIdx+1:], subPostorder[splitIdx:lastIdxAtSubPostorder])
+}
+
+func processToCache() {
+	cache = make(map[int]int)
+	for idx, value := range inorder {
+		cache[value] = idx
+	}
+}
+
+func splitTreeVer3(subInorder, subPostorder []int, offset int) {
+	if len(subInorder) == 0 {
+		return
+	}
+
+	lastIdxAtSubPostorder := len(subPostorder) - 1
+	root := subPostorder[lastIdxAtSubPostorder]
+	writer.WriteString(strconv.Itoa(root) + " ")
+	splitIdx := cache[root] - offset
+
+	frontSubInorder := subInorder[: splitIdx]
+	frontSubPostorder := subPostorder[: splitIdx]
+	splitTreeVer3(frontSubInorder, frontSubPostorder, offset)
+
+	backSubInorder := subInorder[splitIdx + 1 :]
+	backSubPostorder := subPostorder[splitIdx : lastIdxAtSubPostorder]
+	splitTreeVer3(backSubInorder, backSubPostorder, offset + len(frontSubInorder) + 1)
+}


### PR DESCRIPTION
## 🍔 대략적인 풀이

- In-order 순회와 Post-order 순회의 특징을 찾아서 유일한 트리를 식별하여 Pre-order 순회 결과를 출력해야 한다.
- 이진 트리는 사실 Left Sub Tree (Left Node), Root Node, Right Sub Tree (Right Node) 로 이루어진 점을 고려하면, 하나의 큰 트리가 있더라도 작게 작게 쪼개어 작은 Sub Tree 로 생각해서 풀이를 할 수 있다.
- Post-order 의 특징 중 하나는 LRC (Left-Right-Center) 순서로 순회하기 때문에 마지막에 순회한 Node 가 바로 루트 노드일 수 밖에 없다.
- 그리고 In-order 는 LCR 순서임을 고려하여, Post-order 로 부터 찾은 루트 노드가 In-order 어디에 위치했는지 찾으면 해당 index 를 기준으로 Left Sub Tree 와 Right Sub Tree 를 구분할 수 있다.
- 그렇다면 각각의 Sub Tree 에 대해 재귀적으로 다시 루트 노드를 찾고, Sub Tree 의 Left Sub Tree 와 Right Sub Tree 에 대해 또 다시 같은 과정을 반복한다. 재귀 함수는 Sub Tree 의 사이즈가 0 일 때까지 반복한다.
- 이때 문제에서 요구한 Pre-order 는 CLR 순서이므로 루트 노드를 찾을 때마다 바로바로 출력하면 결국에 Pre-order 순회한 결과가 나오게 된다. 즉, 구한 트리를 굳이 저장하지 않고 바로바로 Pre-order 순회 순서로 출력해서 메모리를 아꼈다.
- 추가로, 재귀 함수 내에서 많이 반복되는 부분이 In-order 에서 루트 노드 index 를 찾는 과정인데 이 부분을 Map 자료 구조를 활용해서 소요 시간을 단축했다.



## 🍠 소요 메모리, 시간

1. 첫 번째 시도: 53576KB, 1968ms

   ```go
   func splitTreeVer1(beginIdxAtInorder, beginIdxAtPostorder, size int) {
   	if size == 1 {
   		writer.WriteString(strconv.Itoa(inorder[beginIdxAtInorder]) + " ")
   		return
   	}
   
   	// Post-order 의 시작 index 에 Sub Tree 크기를 더하고 1 을 빼면, 마지막 Post-order index 이다.
   	lastIdxAtPostorder := beginIdxAtPostorder + size - 1
   	root := postorder[lastIdxAtPostorder]
   	writer.WriteString(strconv.Itoa(root) + " ")
   
   	// 위에서 구한 root 가 In-order 에서는 어느 index 에 위치했는지 찾는다.
   	var splitIdxAtInorder int
   	for idx := beginIdxAtInorder; idx < numOfVertex; idx++ {
   		if inorder[idx] == root {
   			splitIdxAtInorder = idx
   			break
   		}
   	}
   
   	// In-order 에서의 root index 를 기점으로 앞부분과 뒷부분 Sub Tree 에 대해 재귀 함수 처리한다.
   	frontSplitSize := splitIdxAtInorder - beginIdxAtInorder
   	if frontSplitSize > 0 {
   		splitTreeVer1(beginIdxAtInorder, beginIdxAtPostorder, frontSplitSize)
   	}
   
   	backSplitSize := size - frontSplitSize - 1
   	if backSplitSize > 0 {
   		splitTreeVer1(splitIdxAtInorder + 1, beginIdxAtPostorder +frontSplitSize, backSplitSize)
   	}
   }
   ```

   - `splitTreeVer1()` 함수에서는 초반에 입력받은 `inorder []int` 와 `postorder []int` 를 그대로 가져다가 쓰면서 접근할 index 만 바꾸어 재귀함수를 호출하는 방식으로 동작했다.
   - In-order 에서의 시작 index, Post-order 에서의 시작 index, 그리고 해당 Sub Tree의 크기를 알고 있으면 각 Sub Tree 를 식별할 수 있다.

2. 두 번째 시도: 32760KB, 1020ms

   ```go
   func splitTreeVer2(subInorder, subPostorder []int) {
   	if len(subInorder) == 0 {
   		return
   	}
   
   	lastIdxAtSubPostorder := len(subPostorder)-1
   	root := subPostorder[lastIdxAtSubPostorder]
   	writer.WriteString(strconv.Itoa(root) + " ")
   
   	var splitIdx int
   	for idx, value := range subInorder {
   		if value == root {
   			splitIdx = idx
   			break
   		}
   	}
   
   	splitTreeVer2(subInorder[:splitIdx], subPostorder[:splitIdx])
   	splitTreeVer2(subInorder[splitIdx+1:], subPostorder[splitIdx:lastIdxAtSubPostorder])
   }
   ```

   - 첫 번째 방법과 로직은 동일하나, index 를 파라미터로 받아서 접근했던 것에서 부분 슬라이스를 파라미터로 전달하는 방식으로 바꾸었다.
   - 사실 문제를 처음 풀 때 재귀 함수를 호출할 때마다 슬라이스를 파라미터로 전달해버리면 너무 많은 메모리를 잡아 먹을 것 같아서 index 를 전달하는 방식으로 선택한 것인데, 결과를 보니 그렇지 않았다.
   - 더불어서, 재귀 함수가 호출될 때마다 전달되는 슬라이스의 크기가 점점 작아지므로 슬라이스를 훑는데 걸리는 시간도 단축되어 결과적으로 소요 시간이 많이 단축되었다.

3. 세 번째 시도: 42340KB, 100ms

   ```go
   func processToCache() {
   	cache = make(map[int]int)
   	for idx, value := range inorder {
   		cache[value] = idx
   	}
   }
   
   func splitTreeVer3(subInorder, subPostorder []int, offset int) {
   	if len(subInorder) == 0 {
   		return
   	}
   
   	lastIdxAtSubPostorder := len(subPostorder) - 1
   	root := subPostorder[lastIdxAtSubPostorder]
   	writer.WriteString(strconv.Itoa(root) + " ")
   	splitIdx := cache[root] - offset
   
   	frontSubInorder := subInorder[: splitIdx]
   	frontSubPostorder := subPostorder[: splitIdx]
   	splitTreeVer3(frontSubInorder, frontSubPostorder, offset)
   
   	backSubInorder := subInorder[splitIdx + 1 :]
   	backSubPostorder := subPostorder[splitIdx : lastIdxAtSubPostorder]
   	splitTreeVer3(backSubInorder, backSubPostorder, offset + len(frontSubInorder) + 1)
   }
   ```

   - 매번 재귀 함수에서 Sub In-order 에서 루트 노드가 어디에 위치 했는지 찾는 과정이 많이 반복되어 오래걸리는 것 같아 Map을 사용해보았다.
   - `processToCache()` 함수가 `inorder []int`에 대해 최초 1회만 프로세싱한다.
   - 이때 각 재귀 함수에서의 Sub In-order 와 Sub Post-order 의 index 가 어긋나 있으므로 이를 조정해 줄 `offset`을 사용한다.

   