### PR TITLE
[G3] 11437 LCA

### DIFF
--- a/week03/assignment02/11437_LCA_HyeonjinChoi.go
+++ b/week03/assignment02/11437_LCA_HyeonjinChoi.go
@@ -33,19 +33,14 @@ type Tree struct {
 	linkedNode []int
 }
 
-// 정점의 부모 정점과 깊이를 저장하기 위한 구조체
-type Node struct {
-	parentNode int
-	depth      int
-}
-
 var (
-	sc       *bufio.Scanner
-	wr       *bufio.Writer
-	nodeNum  int
-	treeArr  []Tree
-	nodeArr  []Node
-	checkArr []bool
+	sc        *bufio.Scanner
+	wr        *bufio.Writer
+	nodeNum   int
+	treeArr   []Tree
+	depthArr  []int
+	checkArr  []bool
+	parentArr [][]int
 )
 
 func init() {
@@ -82,11 +77,18 @@ func setting() {
 // BFS 알고리즘을 이용하여 모든 정점의 부모 정점와 깊이를 구하는 함수
 func findParentAndDepth() {
 	q := Queue{}
-	nodeArr = make([]Node, nodeNum+1)
+	depthArr = make([]int, nodeNum+1)
 	checkArr = make([]bool, nodeNum+1)
+	parentArr = make([][]int, nodeNum+1)
+	for i := 0; i < nodeNum+1; i++ {
+		parentArr[i] = make([]int, 20)
+	}
+
 	q.Enqueue(1)
-	nodeArr[1] = Node{0, 0}
+	depthArr[1] = 0
 	checkArr[1] = true
+	// parentArr[i][j] : i번 정점의 2^j번째 부모 정점
+	parentArr[1][0] = 1
 
 	for {
 		if q.IsEmpty() {
@@ -98,9 +100,17 @@ func findParentAndDepth() {
 		for _, node := range treeArr[curNode].linkedNode {
 			if !checkArr[node] {
 				q.Enqueue(node)
-				nodeArr[node] = Node{curNode, nodeArr[curNode].depth + 1}
+				depthArr[node] = depthArr[curNode] + 1
 				checkArr[node] = true
+				parentArr[node][0] = curNode
 			}
+		}
+	}
+
+	for i := 1; i < 20; i++ {
+		for j := 1; j < nodeNum+1; j++ {
+			// 어떤 정점의 2^i번째 부모 정점은, 그 정점의 2^(i-1)번째 부모 정점의 2^(i-1)번째 부모 정점
+			parentArr[j][i] = parentArr[parentArr[j][i-1]][i-1]
 		}
 	}
 }
@@ -116,31 +126,32 @@ func printCommonParent() {
 
 // 두 정점 각각의 부모 정점을 비교하여 공통 조상을 찾는 함수
 func compareParent(node1, node2 int) int {
-	newNode1, newNode2 := compareDepth(node1, node2)
-
-	for {
-		if newNode1 == newNode2 {
-			return newNode1
-		} else {
-			newNode1 = nodeArr[newNode1].parentNode
-			newNode2 = nodeArr[newNode2].parentNode
-		}
-	}
-}
-
-// 두 정점 각각의 깊이를 비교하여 더 높은 정점이 낮은 정점의 깊이만큼 이동하는 함수
-func compareDepth(node1, node2 int) (int, int) {
 	newNode1, newNode2 := node1, node2
 
-	if nodeArr[node1].depth > nodeArr[node2].depth {
-		for i := 0; i < nodeArr[node1].depth-nodeArr[node2].depth; i++ {
-			newNode1 = nodeArr[newNode1].parentNode
-		}
-	} else if nodeArr[node1].depth < nodeArr[node2].depth {
-		for i := 0; i < nodeArr[node2].depth-nodeArr[node1].depth; i++ {
-			newNode2 = nodeArr[newNode2].parentNode
+	if depthArr[node1] > depthArr[node2] {
+		newNode1, newNode2 = node2, node1
+	}
+
+	for i := 19; i >= 0; i-- {
+		sub := depthArr[newNode2] - depthArr[newNode1]
+
+		// 비트연산을 통해 깊이 차를 빠르게 구함
+		if sub >= (1 << i) {
+			newNode2 = parentArr[newNode2][i]
 		}
 	}
 
-	return newNode1, newNode2
+	if newNode1 == newNode2 {
+		return newNode1
+	} else {
+		// LCA를 구할 때까지 반복
+		for i := 19; i >= 0; i-- {
+			if parentArr[newNode1][i] != parentArr[newNode2][i] {
+				newNode1 = parentArr[newNode1][i]
+				newNode2 = parentArr[newNode2][i]
+			}
+		}
+
+		return parentArr[newNode1][0]
+	}
 }

--- a/week03/assignment02/11437_LCA_HyeonjinChoi.go
+++ b/week03/assignment02/11437_LCA_HyeonjinChoi.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+)
+
+type Queue struct {
+	data []int
+}
+
+func (q *Queue) IsEmpty() bool {
+	return len(q.data) == 0
+}
+
+func (q *Queue) Peek() int {
+	front := q.data[0]
+
+	if !q.IsEmpty() {
+		q.data = q.data[1:]
+	}
+
+	return front
+}
+
+func (q *Queue) Enqueue(num int) {
+	q.data = append(q.data, num)
+}
+
+// 정점의 연결 정보를 나타내는 구조체
+type Tree struct {
+	linkedNode []int
+}
+
+// 정점의 부모 정점과 깊이를 저장하기 위한 구조체
+type Node struct {
+	parentNode int
+	depth      int
+}
+
+var (
+	sc       *bufio.Scanner
+	wr       *bufio.Writer
+	nodeNum  int
+	treeArr  []Tree
+	nodeArr  []Node
+	checkArr []bool
+)
+
+func init() {
+	sc = bufio.NewScanner(os.Stdin)
+	sc.Split(bufio.ScanWords)
+	wr = bufio.NewWriter(os.Stdout)
+}
+
+func scanInt() int {
+	sc.Scan()
+	num, _ := strconv.Atoi(sc.Text())
+	return num
+}
+
+func main() {
+	defer wr.Flush()
+	setting()
+	findParentAndDepth()
+	printCommonParent()
+}
+
+// 정점의 연결 정보를 입력받아 저장하는 함수
+func setting() {
+	nodeNum = scanInt()
+	treeArr = make([]Tree, nodeNum+1)
+
+	for i := 0; i < nodeNum-1; i++ {
+		node1, node2 := scanInt(), scanInt()
+		treeArr[node1].linkedNode = append(treeArr[node1].linkedNode, node2)
+		treeArr[node2].linkedNode = append(treeArr[node2].linkedNode, node1)
+	}
+}
+
+// BFS 알고리즘을 이용하여 모든 정점의 부모 정점와 깊이를 구하는 함수
+func findParentAndDepth() {
+	q := Queue{}
+	nodeArr = make([]Node, nodeNum+1)
+	checkArr = make([]bool, nodeNum+1)
+	q.Enqueue(1)
+	nodeArr[1] = Node{0, 0}
+	checkArr[1] = true
+
+	for {
+		if q.IsEmpty() {
+			break
+		}
+
+		curNode := q.Peek()
+
+		for _, node := range treeArr[curNode].linkedNode {
+			if !checkArr[node] {
+				q.Enqueue(node)
+				nodeArr[node] = Node{curNode, nodeArr[curNode].depth + 1}
+				checkArr[node] = true
+			}
+		}
+	}
+}
+
+func printCommonParent() {
+	num := scanInt()
+
+	for i := 0; i < num; i++ {
+		node1, node2 := scanInt(), scanInt()
+		wr.WriteString(strconv.Itoa(compareParent(node1, node2)) + "\n")
+	}
+}
+
+// 두 정점 각각의 부모 정점을 비교하여 공통 조상을 찾는 함수
+func compareParent(node1, node2 int) int {
+	newNode1, newNode2 := compareDepth(node1, node2)
+
+	for {
+		if newNode1 == newNode2 {
+			return newNode1
+		} else {
+			newNode1 = nodeArr[newNode1].parentNode
+			newNode2 = nodeArr[newNode2].parentNode
+		}
+	}
+}
+
+// 두 정점 각각의 깊이를 비교하여 더 높은 정점이 낮은 정점의 깊이만큼 이동하는 함수
+func compareDepth(node1, node2 int) (int, int) {
+	newNode1, newNode2 := node1, node2
+
+	if nodeArr[node1].depth > nodeArr[node2].depth {
+		for i := 0; i < nodeArr[node1].depth-nodeArr[node2].depth; i++ {
+			newNode1 = nodeArr[newNode1].parentNode
+		}
+	} else if nodeArr[node1].depth < nodeArr[node2].depth {
+		for i := 0; i < nodeArr[node2].depth-nodeArr[node1].depth; i++ {
+			newNode2 = nodeArr[newNode2].parentNode
+		}
+	}
+
+	return newNode1, newNode2
+}


### PR DESCRIPTION
##  대략적인 풀이
- 우선 정점의 연결 정보를 입력받아서 `treeArr[]`에 저장한다.
`treeArr[i].linkedNode[]`는 i번 정점과 연결된 정점들이 저장된 배열을 나타낸다.
- BFS 알고리즘을 이용하여 루트인 1번 정점부터  모든 정점을 탐색하며 부모 정점과 깊이를 구한다.
`nodeArr[i].parentNode, nodeArr[i].depth`는 각각 i번 정점의 부모 정점과 깊이를 나타낸다.
- 공통 조상을 알고싶은 두 정점에 대하여 `compareParent()`를 진행한다.
두 정점 각각의 부모 정점을 비교하기 전에 우선 두 정점의 깊이부터 비교한다.
깊이를 비교하여 더 깊은 정점이 얕은 정점 깊이만큼 올라오면 부모 정점을 비교한다.
부모 정점을 찾을 때까지 상위 정점으로 이동하며 비교한다.


## 소요 메모리, 시간
- 첫 번째 시도 : 8812KB, 988ms
  - 상당히 높은 소요를 보이고 있다. 알고리즘을 수정하여 성능 완화를 위한 보완이 필요해보인다.
- 두 번째 시도 : 19152KB, 76ms
  - 기존 방식에서 높은 시간소요에 가장 크게 영향을 준 부분은 공통 조상을 찾는 함수였다.
  두 정점을 비교하기 전 동일한 깊이를 맞춰주는 함수가 있었다.
  <br/>
  
  ```go
  func compareDepth(node1, node2 int) (int, int) {
	newNode1, newNode2 := node1, node2

	if nodeArr[node1].depth > nodeArr[node2].depth {
		for i := 0; i < nodeArr[node1].depth-nodeArr[node2].depth; i++ {
			newNode1 = nodeArr[newNode1].parentNode
		}
	} else if nodeArr[node1].depth < nodeArr[node2].depth {
		for i := 0; i < nodeArr[node2].depth-nodeArr[node1].depth; i++ {
			newNode2 = nodeArr[newNode2].parentNode
		}
	}

	return newNode1, newNode2
  }
  ```
  `compareDepth()`는 깊이를 비교하여 더 깊은 정점을 한 단계씩 올리는 작업을 하였다.
  하지만 두 정점의 깊이의 차이가 클수록 영향을 크게 끼치기 때문에 다른 방식으로 수정할 필요가 있었다.
  - 기존에는 부모 정점과 깊이를 멤버로 갖는 구조체 배열을 사용하여 
  모든 정점마다 자신의 부모 정점과 깊이를 저장할 수 있게 만들었다.
  이에 대한 개선책으로 사용한 것이 `parentArr[][]`이다.
  `parentArr[i][j]`는 i번 정점의 2^j번째 부모 정점을 나타낸다. 이 방식을 사용하면 다음과 같은 점화식을 사용할 수 있는데,
  `parentArr[j][i] = parentArr[parentArr[j][i-1]][i-1]`
  다음과 같은 비트연산을 이용하면,
  `difference >= (1 << index)` 깊이를 맞출 때 한 단계씩 올라가는 것이 아니라 많은 단계를 생략할 수 있다.
  또한 깊이를 맞춘 이후에 LCA를 찾을 때도 `parentArr[][]`를 통해 시간을 단축시킬 수 있다.
  <br/>
  
  ```go
  for i := 19; i >= 0; i-- {
	if parentArr[newNode1][i] != parentArr[newNode2][i] {
		newNode1 = parentArr[newNode1][i]
		newNode2 = parentArr[newNode2][i]
	}
  }
  ```
  여유있는 깊이부터 시작하여 절반씩 줄이며 공통 조상이 아닐 때까지 탐색하고,
  공통 조상이 아닌 시점부터 다시 절반씩 줄이며 올라가서 최소 공통 조상을  찾는다.