### PR TITLE
[G3] 2263 트리의 순회

### DIFF
--- a/week03/assignment03/2263_트리의 순회_HyeonjinChoi.go
+++ b/week03/assignment03/2263_트리의 순회_HyeonjinChoi.go
@@ -35,9 +35,10 @@ func scanInt() int {
 func main() {
 	defer wr.Flush()
 	setting()
-	generateTree()
+	solve(0, nodeNum-1, nodeNum-1)
 }
 
+// 인오더, 포스트오더에 해당하는 수를 입력받는 함수
 func setting() {
 	nodeNum = scanInt()
 	inOrderArr = make([]int, nodeNum)
@@ -52,6 +53,27 @@ func setting() {
 	}
 }
 
-func generateTree() {
-	
+// 인자로 받은 범위 내에서 루트를 찾고 출력, 이후 좌측 우측 자식정점 순으로 반복
+func solve(startIdx, endIdx, rootIdx int) {
+	midIdx := findIdx(postOrderArr[rootIdx])
+	wr.WriteString(strconv.Itoa(inOrderArr[midIdx]) + " ")
+
+	if startIdx <= midIdx-1 {
+		solve(startIdx, midIdx-1, rootIdx-1-(endIdx-midIdx))
+	}
+
+	if midIdx+1 <= endIdx {
+		solve(midIdx+1, endIdx, rootIdx-1)
+	}
+}
+
+// inOrderArr[]에서 인자로 받은 값에 해당하는 인덱스를 찾는 함수
+func findIdx(num int) int {
+	for index, data := range inOrderArr {
+		if data == num {
+			return index
+		}
+	}
+
+	return -1
 }

--- a/week03/assignment03/2263_트리의 순회_HyeonjinChoi.go
+++ b/week03/assignment03/2263_트리의 순회_HyeonjinChoi.go
@@ -18,6 +18,7 @@ var (
 	nodeNum      int
 	inOrderArr   []int
 	postOrderArr []int
+	findIdxArr   []int
 )
 
 func init() {
@@ -43,9 +44,12 @@ func setting() {
 	nodeNum = scanInt()
 	inOrderArr = make([]int, nodeNum)
 	postOrderArr = make([]int, nodeNum)
+	findIdxArr = make([]int, nodeNum+1)
 
 	for i := 0; i < nodeNum; i++ {
 		inOrderArr[i] = scanInt()
+		// inOrderArr[]에 대한 역 인덱스 배열을 생성
+		findIdxArr[inOrderArr[i]] = i
 	}
 
 	for i := 0; i < nodeNum; i++ {
@@ -55,7 +59,7 @@ func setting() {
 
 // 인자로 받은 범위 내에서 루트를 찾고 출력, 이후 좌측 우측 자식정점 순으로 반복
 func solve(startIdx, endIdx, rootIdx int) {
-	midIdx := findIdx(postOrderArr[rootIdx])
+	midIdx := findIdxArr[postOrderArr[rootIdx]]
 	wr.WriteString(strconv.Itoa(inOrderArr[midIdx]) + " ")
 
 	if startIdx <= midIdx-1 {
@@ -65,15 +69,4 @@ func solve(startIdx, endIdx, rootIdx int) {
 	if midIdx+1 <= endIdx {
 		solve(midIdx+1, endIdx, rootIdx-1)
 	}
-}
-
-// inOrderArr[]에서 인자로 받은 값에 해당하는 인덱스를 찾는 함수
-func findIdx(num int) int {
-	for index, data := range inOrderArr {
-		if data == num {
-			return index
-		}
-	}
-
-	return -1
 }

--- a/week03/assignment03/2263_트리의 순회_HyeonjinChoi.go
+++ b/week03/assignment03/2263_트리의 순회_HyeonjinChoi.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+)
+
+type Node struct {
+	parent int
+	left   int
+	right  int
+}
+
+var (
+	sc           *bufio.Scanner
+	wr           *bufio.Writer
+	nodeNum      int
+	inOrderArr   []int
+	postOrderArr []int
+)
+
+func init() {
+	sc = bufio.NewScanner(os.Stdin)
+	sc.Split(bufio.ScanWords)
+	wr = bufio.NewWriter(os.Stdout)
+}
+
+func scanInt() int {
+	sc.Scan()
+	num, _ := strconv.Atoi(sc.Text())
+	return num
+}
+
+func main() {
+	defer wr.Flush()
+	setting()
+	generateTree()
+}
+
+func setting() {
+	nodeNum = scanInt()
+	inOrderArr = make([]int, nodeNum)
+	postOrderArr = make([]int, nodeNum)
+
+	for i := 0; i < nodeNum; i++ {
+		inOrderArr[i] = scanInt()
+	}
+
+	for i := 0; i < nodeNum; i++ {
+		postOrderArr[i] = scanInt()
+	}
+}
+
+func generateTree() {
+	
+}


### PR DESCRIPTION
## 대략적인 풀이
- 포스트오더의 특성상 마지막 정점은 루트인 점을 이용한다.
두 자식 정점 사이에 부모 정점이 오는 인오더와 비교하며
루트를 기준으로 좌측, 우측 트리로 분할한다.
- 루트는 바로 출력하고 좌측, 우측 트리는 재귀적 방식으로 반복한다.

## 소요 메모리, 시간
- 첫번째 시도 : 31396KB, 2100ms
  - 상당한 시간 소요를 보였는데, 이는 포스트오더에서 찾은 루트를 이용하여
  인오더 내의 기준 인덱스를 찾는 함수에서 기인한 것으로 추정된다.
- 두번째 시도 : 32272KB, 100ms
  - 첫번째 시도에서 사용한 `findIdx()`는 불필요한 탐색 때문에 많은 시간 소요가 있었다.
  이는 정점의 개수가 늘어날수록 더욱 큰 영향을 끼치게 때문에 다른 방식을 사용했다.
  <br/>
  
  ```go
  func findIdx(num int) int {
	for index, data := range inOrderArr {
		if data == num {
			return index
		}
	}

	return -1
  }
  ```
  기존에는 인오더에서 모든 값을 비교하며 루트를 찾았는데, 이 함수 자체를 사용하지 않고 역 인덱스 배열을 생성하여 사용하였다.
  `findIdxArr[inOrderArr[i]] = i`
  역 인덱스 배열을 사용하면 탐색하고자 하는 값에 대한 인덱스를 바로 찾을 수 있어 불필요한 시간 소요를 방지한다.