### PR TITLE
[G4] 1967 트리의 지름

### DIFF
--- a/week02/assignment02/BOJ_1967_joonparkhere.java
+++ b/week02/assignment02/BOJ_1967_joonparkhere.java
@@ -1,0 +1,82 @@
+package assignment02;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_1967_joonparkhere {
+
+    private static class Node {
+        private final int idx;
+        private final int weight;
+
+        public Node(int idx, int weight) {
+            this.idx = idx;
+            this.weight = weight;
+        }
+    }
+
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    private static final List<List<Node>> graph = new ArrayList<>();
+
+    private static int[] distance;
+    private static int numOfNode = 0;
+    private static int endNodeIdx = 0;
+    private static int diameter = 0;
+
+    public static void main(String[] args) throws IOException {
+        initTree();
+        distance = new int[numOfNode + 1];
+
+        Arrays.fill(distance, -1);
+        distance[1] = 0;
+        dfs(1);
+        updateFarthestNode();
+
+        Arrays.fill(distance, -1);
+        distance[endNodeIdx] = 0;
+        dfs(endNodeIdx);
+        updateFarthestNode();
+
+        bw.append(String.valueOf(diameter));
+        bw.flush();
+        bw.close();
+    }
+
+    private static void initTree() throws IOException {
+        numOfNode = Integer.parseInt(br.readLine());
+        for (int idx = 0; idx <= numOfNode; idx++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for (int i = 1; i < numOfNode; i++) {
+            String[] input = br.readLine().split(" ");
+            int parent = Integer.parseInt(input[0]);
+            int child = Integer.parseInt(input[1]);
+            int weight = Integer.parseInt(input[2]);
+
+            graph.get(parent).add(new Node(child, weight));
+            graph.get(child).add(new Node(parent, weight));
+        }
+    }
+
+    private static void dfs(int current) {
+        for (Node next : graph.get(current)) {
+            if (distance[next.idx] != -1) {
+                continue;
+            }
+            distance[next.idx] = distance[current] + next.weight;
+            dfs(next.idx);
+        }
+    }
+
+    private static void updateFarthestNode() {
+        for (int i = 1; i <= numOfNode; i++) {
+            if (diameter < distance[i]) {
+                diameter = distance[i];
+                endNodeIdx = i;
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
이전에 Golang으로 풀었던 문제를 Java로 다시 풀어보았다.

@HyeonjinChoi 님이 제안해주신 방법대로, DFS를 2번만 수행해서 트리의 지름을 찾는 방식대로 풀이 했다. 풀었던 문제이므로 자세한 풀이 방법은 생략하겠다.

## 출처
[[BOJ] 1967 트리의 지름](https://www.acmicpc.net/problem/1967)

## 소요 메모리와 시간
1. 24676 KB, 224 ms
    - 처음에 Golang으로 문제를 풀 때와 달리 확실히 트리의 성질을 알고 풀이하니, 성능이 훨씬 개선되었다.