### PR TITLE
[G2] 2613 숫자구슬

### DIFF
--- a/week06/assignment02/BOJ_2613_joonparkhere.go
+++ b/week06/assignment02/BOJ_2613_joonparkhere.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+)
+
+var (
+	scanner = bufio.NewScanner(os.Stdin)
+	writer = bufio.NewWriter(os.Stdout)
+	numOfItem int
+	numOfGroup int
+	weights []int
+)
+
+func scanIntArray() []int {
+	scanner.Scan()
+	idx := 0
+	array := make([]int, 1)
+	for _, c := range scanner.Bytes() {
+		if c == ' ' {
+			idx++
+			array = append(array, 0)
+			continue
+		}
+		array[idx] = array[idx] * 10 + int(c - '0')
+	}
+	return array
+}
+
+func main() {
+	defer writer.Flush()
+	large, sum := input()
+	solve(large, sum)
+}
+
+func input() (int, int) {
+	inputArray := scanIntArray()
+	numOfItem, numOfGroup = inputArray[0], inputArray[1]
+
+	weights = make([]int, numOfItem)
+	large, sum := 0, 0
+
+	inputArray = scanIntArray()
+	for idx, weight := range inputArray {
+		weights[idx] = weight
+		if large < weight {
+			large = weight
+		}
+		sum += weight
+	}
+
+	return large, sum
+}
+
+func solve(large, curSum int) {
+	left, right := large, curSum
+	for left <= right {
+		mid := (left + right) / 2
+		if canPartition(mid) {
+			right = mid - 1
+		} else {
+			left = mid + 1
+		}
+	}
+
+	targetSum := left
+	writer.WriteString(strconv.Itoa(targetSum) + "\n")
+
+	curSum, itemCount, remainNumOfGroup := 0, 0, numOfGroup
+	for idx, weight := range weights {
+		curSum += weight
+		itemCount++
+
+		if curSum > targetSum {
+			writer.WriteString(strconv.Itoa(itemCount - 1) + " ")
+			curSum = weight
+			itemCount = 1
+			remainNumOfGroup--
+		}
+
+		if remainNumOfItem := numOfItem-idx; remainNumOfItem == remainNumOfGroup {
+			break
+		}
+	}
+
+	for i := 0; i < remainNumOfGroup; i++ {
+		writer.WriteString(strconv.Itoa(itemCount) + " ")
+		itemCount = 1
+	}
+}
+
+func canPartition(mid int) bool {
+	curSum, groupCount := 0, 1
+	for _, weight := range weights {
+		curSum += weight
+		if curSum > mid {
+			curSum = weight
+			groupCount++
+		}
+	}
+	return groupCount <= numOfGroup
+}


### PR DESCRIPTION
## 출처

[[BOJ] 2613 숫자구슬](https://www.acmicpc.net/problem/2613)



## 대략적인 풀이

- 처음에 접근할 때는 조합을 이용하려 했다.

  구슬 `N`개를 `M`개의 그룹으로 나누는 것이므로, 구슬과 구슬 사이 공간의 개수 `N-1` 중에서 칸막이를 둘 곳을 `M-1`개 정해주면 된다고 생각해서 경우의 수 `C(N-1, M-1)`만큼 각각의 경우들을 따져보려 했다.

  문제의 조건은 `1<=M<=N<=300`이므로 `C(n, r)` 구현 시 비트마스킹 방법으로 구현하려면 `N<=300`인 점을 고려해, 변수가 `2^300`인 수까지 표현 가능해야 했다. 따라서 오버플로우가 발생하지 않으며 큰 수를 다룰 수 있는 `big.Int` 타입을 사용해야만 했다.

  하지만 가능한 경우가 너무나도 많기 때문에 `C(N-1, M-1)`만큼의 반복은 시간 초과가 났다.

- 결국 대강의 타깃 알고리즘을 알아보고 문제를 풀었다.

  이 문제는 Binary Search를 활용한 형태의 Parametric Search를 이용하는 문제였다. ([개념 참고 블로그](https://coderkoo.tistory.com/8))

  즉, 이진 탐색에서의 `left`와 `right`은 각각 요소 총합의 최솟값과 최댓값을 의미한다. 예를 들어 아래처럼 값이 주어졌을 때

  ```
  8 3
  5 4 2 6 9 3 8 7
  ```

   초기 `left`는 9, `right`는 44이다. 그리고 다음 코드 흐름으로 문제에서 요구하는 목표 값을 찾는다.

  ```
  while (left <= right)
      mid = (left + right) / 2
      if (canPartition(mid))
          right = mid - 1
      else
          left = mid + 1
  ```

  `canPartition()` 함수는 파라미터로 넘어온 `mid` 값을 토대로, `M`개 이하의 그룹들로 나눌 수 있는 지 판별한다.

  즉, 조건문이 만족하면 그룹의 수를 늘려야 하므로 `mid` 값을 감소시켜야 한다. 그래서 `right`값이 위 코드처럼 변경되는 것이고 조건문이 만족하지 않으면 그룹의 수를 줄여야 하므로 `mid` 값을 증가시켜야 한다. 그래서 `left` 값이 위 코드처럼 변경되는 것이다.

  위 반복문이 종료되면 `left` 값이 찾고자 하는 그룹 내 요소 합 중 최댓값의 최소값이다. 그리고 해당 값을 토대로 각 그룹을 구성하는 요소의 수를 출력하면 문제를 해결할 수 있다.



## 소요 메모리와 시간

1. 조합을 활용한 풀이 시도

   - 시간 초과

     기본적으로 주어진 시간 제한이 1초로 짧은 편인데, 가능한 최대의 경우의 수가 `C(300, 150) = 93759702772827452793193754439064084879232655700081358920472352712975170021839591675861424` 이기 때문에 조합으로 풀이 시 시간 초과로 인해 통과하지 못한다.

     다음은 `big.Int` 타입을 이용해 구현한 조합 풀이 코드이다.

     ```go
     func findCases() []*big.Int {
     	cases := make([]*big.Int, 0)
     
     	bit := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(numOfGroup-1)), big.NewInt(1))	// (1 << (numOfGroup - 1)) - 1
     	limit := new(big.Int).Lsh(big.NewInt(1), uint(numOfItem-1))	// bit < (1 << (numOfItem - 1))
     
     	for (bit.Cmp(big.NewInt(0)) >= 0) && (bit.Cmp(limit) < 0) {
     		element := new(big.Int).Add(new(big.Int).Lsh(bit, 1), big.NewInt(1))	// (bit << 1) + 1
     		cases = append(cases, element)
     
     		subA := new(big.Int).Set(bit)	// bit
     		subB := new(big.Int).Sub(new(big.Int).And(new(big.Int).Set(bit), new(big.Int).Neg(bit)), big.NewInt(1))	// (bit & -bit) - 1
     		tmp := new(big.Int).Or(subA, subB)	// bit | ((bit & -bit) - 1)
     
     		subX := new(big.Int).Sub(new(big.Int).And(new(big.Int).Not(tmp), new(big.Int).Neg(new(big.Int).Not(tmp))), big.NewInt(1)) // (^tmp & -^tmp) - 1
     		subY := bit.TrailingZeroBits() + 1	// num of trailing zero bits + 1
     		subZ := new(big.Int).Add(tmp, big.NewInt(1))	// tmp + 1
     		bit = new(big.Int).Or(subZ, new(big.Int).Rsh(subX, subY))	// (tmp + 1) | (((^tmp & -^tmp) - 1) >> (getNumOfTrailingZeros(bit) + 1))
     	}
     
     	return cases
     }
     
     func findAnswers(cases []*big.Int) (int, []int) {
     	minSum := 300 * 100
     	sizes := make([]int, numOfGroup)
     
     	for _, bit := range cases {
     		msb := new(big.Int).Lsh(big.NewInt(1), uint(numOfItem))	// 1 << numOfItem
     		size, tempSum, caseSum := 0, 0, 0
     		curSizes := make([]int, 0)
     
     		for i := 0; i < numOfItem; i++ {
     			msb.Rsh(msb, 1)	// msb >>= 1
     			size++
     			tempSum += weights[i]
     
     			tmp := new(big.Int).And(msb, bit)
     			if tmp.Cmp(big.NewInt(0)) == 0 {	// (msb & bit) == 0
     				continue
     			}
     
     			if tempSum > caseSum {
     				caseSum = tempSum
     			}
     			curSizes = append(curSizes, size)
     			size, tempSum = 0, 0
     		}
     
     		if caseSum < minSum {
     			minSum = caseSum
     			sizes = curSizes
     		}
     	}
     
     	return minSum, sizes
     }
     ```

     

2. Parametric Search로 풀이

   - 900 KB, 8 ms

     다른 Golang 풀이 코드가 없어서 비교가 힘들지만, C++ 풀이 코드와 비교 했을 때 소요 시간이 0 ms인 풀이와 알고리즘과 구현 코드가 유사한 것으로 보아, 추가 개선할 필요는 없어 보인다.

