### PR TITLE
[P4] 3653 영화 수집

### DIFF
--- a/week04/assignment03/BOJ_3653_HyeonjinChoi.go
+++ b/week04/assignment03/BOJ_3653_HyeonjinChoi.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+)
+
+var (
+	sc       *bufio.Scanner
+	wr       *bufio.Writer
+	n        int
+	m        int
+	max      int
+	treeSize int
+	treeArr  []int
+	dvdPos   []int
+)
+
+func init() {
+	sc = bufio.NewScanner(os.Stdin)
+	sc.Split(bufio.ScanWords)
+	wr = bufio.NewWriter(os.Stdout)
+}
+
+func scanInt() int {
+	sc.Scan()
+	num, _ := strconv.Atoi(sc.Text())
+	return num
+}
+
+func main() {
+	defer wr.Flush()
+	solve()
+}
+
+func solve() {
+	caseNum := scanInt()
+
+	for i := 0; i < caseNum; i++ {
+		setting()
+		findAnswer()
+	}
+}
+
+func setting() {
+	max = 100001
+	treeSize = 1 << 19
+	treeArr = make([]int, treeSize)
+	dvdPos = make([]int, max)
+
+	n, m = scanInt(), scanInt()
+	initTree(1, 1, n+m)
+
+	for i := 1; i <= n; i++ {
+		dvdPos[i] = m + i
+		update(1, 1, n+m, dvdPos[i], 1)
+	}
+}
+
+// DVD 위치 초기화
+func initTree(node, startNode, endNode int) {
+	treeArr[node] = 0
+
+	if startNode == endNode {
+		return
+	}
+
+	left := node * 2
+	right := node*2 + 1
+	midNode := (startNode + endNode) / 2
+	initTree(left, startNode, midNode)
+	initTree(right, midNode+1, endNode)
+}
+
+// index에 해당하는 말단 정점을 value 값으로 갱신
+func update(node, startNode, endNode, index, value int) {
+	if startNode == endNode {
+		treeArr[node] = value
+		return
+	}
+
+	left := node * 2
+	right := node*2 + 1
+	midNode := (startNode + endNode) / 2
+
+	if index > midNode {
+		update(right, midNode+1, endNode, index, value)
+	} else {
+		update(left, startNode, midNode, index, value)
+	}
+
+	treeArr[node] = treeArr[left] + treeArr[right]
+}
+
+func findAnswer() {
+	next := m
+
+	for i := 1; i <= m; i++ {
+		target := scanInt()
+		wr.WriteString(strconv.Itoa(query(1, 1, n+m, 1, dvdPos[target]-1)) + " ")
+
+		update(1, 1, n+m, dvdPos[target], 0)
+		dvdPos[target] = next
+		next--
+		update(1, 1, n+m, dvdPos[target], 1)
+	}
+
+	wr.WriteString("\n")
+}
+
+func query(index, startNode, endNode, left, right int) int {
+	if (right < startNode) || (endNode < left) {
+		return 0
+	}
+
+	if (left <= startNode) && (endNode <= right) {
+		return treeArr[index]
+	}
+
+	midNode := (startNode + endNode) / 2
+	leftNode := index * 2
+	rightNode := index*2 + 1
+
+	return query(leftNode, startNode, midNode, left, right) + query(rightNode, midNode+1, endNode, left, right)
+}

--- a/week04/assignment03/BOJ_3653_HyeonjinChoi.go
+++ b/week04/assignment03/BOJ_3653_HyeonjinChoi.go
@@ -50,27 +50,11 @@ func setting() {
 	dvdPos = make([]int, max)
 
 	n, m = scanInt(), scanInt()
-	initTree(1, 1, n+m)
 
 	for i := 1; i <= n; i++ {
 		dvdPos[i] = m + i
 		update(1, 1, n+m, dvdPos[i], 1)
 	}
-}
-
-// DVD 위치 초기화
-func initTree(node, startNode, endNode int) {
-	treeArr[node] = 0
-
-	if startNode == endNode {
-		return
-	}
-
-	left := node * 2
-	right := node*2 + 1
-	midNode := (startNode + endNode) / 2
-	initTree(left, startNode, midNode)
-	initTree(right, midNode+1, endNode)
 }
 
 // index에 해당하는 말단 정점을 value 값으로 갱신


### PR DESCRIPTION
## 대략적인 풀이
- treeArr[], dvdPos[] 이 두 가지 배열을 통해 문제를 해결한다.
- DVD 개수를 n, 테스트 횟수를 m 이라고 했을 때, treeArr[]의 말단 정점이 n+m 개 이상이 되도록 트리를 생성한다.
- treeArr[] 의 첫 m개의 원소를 비워두고, 이후 m+1부터 m+n개의 원소값을 1로 초기화한다.
- dvdPos[]의 원소값은 index 값과 매칭되는 각 DVD의 treeArr[]에서의 위치를 나타낸다.
ex) 1번 DVD : dvdPos[1] -> m + 1
- DVD를 보고 다시 쌓아올릴 경우에는 treeArr[m - 1] 부터 1씩 index를 감소시키며 저장한다.
테스트가 모두 끝났을 때는, treeArr[1] 값까지 저장되며 완료된다.

## 소요 메모리, 시간
- 23152KB, 328ms
  - 메모리 소요는 평균에 근접하지만 시간 소요가 약간 큰 것으로 보인다.