### PR TITLE
[Easy] 122 Best Time to Buy and Sell Stock II

### DIFF
--- a/week06/assignment01/LEET_122_joonparkhere.java
+++ b/week06/assignment01/LEET_122_joonparkhere.java
@@ -1,0 +1,48 @@
+package assignment01;
+
+import java.io.*;
+
+public class LEET_122_joonparkhere {
+
+    public static int maxProfitVer1(int[] prices) {
+        int sum = 0, idx = 0, low, high;
+        while (idx < prices.length - 1) {
+            while ((idx < prices.length - 1) && (prices[idx] >= prices[idx + 1]))
+                idx++;
+            low = prices[idx];
+
+            while ((idx < prices.length - 1) && (prices[idx] <= prices[idx + 1]))
+                idx++;
+            high = prices[idx];
+
+            sum += high - low;
+        }
+        return sum;
+    }
+
+    public static int maxProfitVer2(int[] prices) {
+        int sum = 0;
+        for (int idx = 0; idx < prices.length - 1; idx++) {
+            if (prices[idx + 1] > prices[idx])
+                sum += prices[idx + 1] - prices[idx];
+        }
+        return sum;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        String[] input = br.readLine().split(",");
+        int[] prices = new int[input.length];
+        for (int i = 0; i < input.length; i++) {
+            prices[i] = Integer.parseInt(input[i]);
+        }
+
+        int result = maxProfitVer2(prices);
+        bw.append(String.valueOf(result));
+        bw.flush();
+        bw.close();
+    }
+
+}


### PR DESCRIPTION
## 출처

[[LEET] 122 Best Time to Buy and Sell Stock II](https://leetcode.com/problems/best-time-to-buy-and-sell-stock-ii/submissions/)



## 대략적인 풀이

- 결과적으로는 그리디 알고리즘으로 간단히 풀이할 수 있는 문제이다.

- 사고 팔기로 한 구간 내에 더 큰 이득을 볼 수 있는 경우가 있는 지 없는 지를 판단하는 게 풀이의 핵심이었다.

- 만약 `[7,1,5,3,6,4]`이 Input으로 들어온다면 둘째 날 사고, 다섯째 날 팔아서 `6-1 = 5` 이득을 볼 수 있는데, 이때 둘째 날과 다섯째 날 구간에서 더 큰 이득을 볼 수 있는 지 판단해야 한다. 이 예시에서는 둘째 날 사고, 셋째 날 팔고, 넷째 날 사고, 다섯째 날 팔면 `5-1 + 6-3 = 7` 이득을 볼 수 있게 된다.

  여기서 잘 생각해보면, 어떤 구간에서 더 큰 이득을 갖는다는 것은 해당 구간 내에 오르락 내리락 하는 서브 구간이 존재해야 한다. 따라서 `prices` 요소들을 앞에서부터 훑으며, 가격이 오르는 시작점과 끝점을 찾아서 두 `price`의 차를 매번 더해 총 합하면 구하고자 하는 답이 된다.

- 위의 생각을 조금 더 간단히 하면, 오르락 내리락하는 구간을 명시할 필요없다.

  단순히 `prices` 요소들을 앞에서부터 훑으며 다음 요소 값이 현재 요소 값보다 크다면 둘의 차를 더하여 구하고자 하는 답을 쉽게 구할 수 있다.



## 소요 메모리와 시간

1. 오르락 내리락하는 구간을 구한 후 둘의 차를 총 합하는 풀이

   - 38.6 MB, 1 ms

     리트코드 제출 통계에 따르면 소요 메모리는 상위 37.98%, 소요 시간은 상위 35.53% 에 속한다.

2. 단순히 가격이 올랐을 경우 둘의 차를 총 합하는 풀이

   - 38.6 MB, 0 ms

     통계에 따르면, 소요 메모리는 상위 0%, 소요 시간은 상위 35.53% 에 속한다.

     구간을 따로 구하지 않고 단순 반복으로 풀이를 하니 속도가 향상된 것 같다.

   

