### PR TITLE
[Level 3] 42627 디스크 컨트롤러

### DIFF
--- a/week07/assignment02/PROG_42627_joonparkhere.java
+++ b/week07/assignment02/PROG_42627_joonparkhere.java
@@ -1,0 +1,69 @@
+package assignment02;
+
+import java.io.*;
+import java.util.*;
+
+public class PROG_42627_joonparkhere {
+
+    static class Job implements Comparable<Job> {
+        int threshold;
+        int cost;
+
+        public Job(int[] arr) {
+            this.threshold = arr[0];
+            this.cost = arr[1];
+        }
+
+        @Override
+        public int compareTo(Job o) {
+            return this.cost - o.cost;
+        }
+    }
+
+    public static int solution(int[][] jobs) {
+        Arrays.sort(jobs, (o1, o2) -> o1[0] - o2[0]);
+        PriorityQueue<Job> heap = new PriorityQueue<>();
+        int result = 0, current = 0, idx = 0, numOfJob = jobs.length;
+
+        while (true) {
+            while ( (idx < numOfJob) && (jobs[idx][0] <= current) ) {
+                heap.add(new Job(jobs[idx]));
+                idx += 1;
+            }
+
+            if (heap.isEmpty()) {
+                if (idx < numOfJob) {
+                    current += 1;
+                    continue;
+                }
+                else {
+                    break;
+                }
+            }
+
+            Job job = heap.remove();
+            result += (current - job.threshold + job.cost);
+            current += job.cost;
+        }
+
+        return result / numOfJob;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        String[] input = br.readLine().split(" ");
+        int[][] jobs = new int[input.length / 2][2];
+        for (int i = 0; i < input.length; i += 2) {
+            jobs[i / 2][0] = Integer.parseInt(input[i]);
+            jobs[i / 2][1] = Integer.parseInt(input[i + 1]);
+        }
+
+        int result = solution(jobs);
+        bw.append(String.valueOf(result));
+        bw.flush();
+        bw.close();
+    }
+
+}


### PR DESCRIPTION
## 출처

[[PROG] 42627 디스크 컨트롤러](https://programmers.co.kr/learn/courses/30/lessons/42627)



## 대략적인 풀이

- 현재 시각이 작업 요청 시점보다 큰 작업들에 대해서, 즉 처리 가능한 작업들에 대해서 소요 시간이 짧은 것들부터 처리하면, 전체적으로 대기 시간이 줄어들어 평균의 최솟값인 답을 구할 수 있다.

- 우선 파라미터로 받아오는 작업 목록을 작업 요청 시점 기준으로 오름차순으로 정렬한 후, 현재 시각을 늘려가며 힙에 처리 가능한 작업들을 집어 넣는다. 이때 힙은 작업의 소요 시간이 짧은 순서로 정렬된다.

  하나 주의할 점은, 특정 시점에 아직 처리하지 않은 작업이 있음에도 처리 가능한 작업들이 없을 수 있다. 이럴 경우에는 현재 시각을 `+1`한 후 다시 반복문을 실행하도록 구현했다.

- 힙이 비어있을 때까지 반복을 하며 작업의 요청부터 종료까지 걸린 시간을 합한 후, 작업 개수로 나누어 답을 구한다.



## 소요 메모리와 시간

1. 67.5 MB, 3.76 ms
   - 프로그래머스 사이트에서 다른 사람들과 효율성 비교를 할 수 없으니 얼마나 부족한 코드인지 확인이 불가능한 점이 아쉽다.

