### PR TITLE
[Level 3] 42627 디스크 컨트롤러

### DIFF
--- a/week07/assignment02/PROG_42627_HyeonjinChoi.go
+++ b/week07/assignment02/PROG_42627_HyeonjinChoi.go
@@ -1,0 +1,108 @@
+import "sort"
+
+// 작업 정보에 대한 구조체
+type Job struct {
+	start int
+	burst int
+}
+
+// min heap 
+type MinHeap []Job
+
+func (h *MinHeap) Push(w Job) {
+	*h = append(*h, w)
+	h.Up(len(*h) - 1)
+}
+
+func (h *MinHeap) Up(idx int) {
+	for h.Compare(idx, ParentNode(idx)) {
+		h.Swap(ParentNode(idx), idx)
+		idx = ParentNode(idx)
+	}
+}
+
+func (h *MinHeap) Pop() Job {
+	popped := (*h)[0]
+	(*h)[0] = (*h)[len(*h)-1]
+	(*h) = (*h)[:len(*h)-1]
+	h.Down(0)
+	return popped
+}
+
+func (h *MinHeap) Down(idx int) {
+	lastIdx := len(*h) - 1
+	l, r := LeftNode(idx), RightNode(idx)
+
+	var childToCompare int
+	for l <= lastIdx {
+		if l == lastIdx {
+			childToCompare = l
+		} else if h.Compare(l, r) {
+			childToCompare = l
+		} else {
+			childToCompare = r
+		}
+
+		if h.Compare(idx, childToCompare) {
+			return
+		}
+		h.Swap(idx, childToCompare)
+		idx = childToCompare
+		l, r = LeftNode(idx), RightNode(idx)
+	}
+}
+
+func (h *MinHeap) Swap(i, j int) {
+	(*h)[i], (*h)[j] = (*h)[j], (*h)[i]
+}
+
+func (h *MinHeap) Compare(i, j int) bool {
+	return (*h)[i].burst < (*h)[j].burst
+}
+
+func ParentNode(i int) int {
+	return (i - 1) / 2
+}
+
+func LeftNode(i int) int {
+	return 2*i + 1
+}
+
+func RightNode(i int) int {
+	return 2*i + 2
+}
+
+func solution(jobs [][]int) int {
+    sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i][0] < jobs[j][0]
+	})
+
+	priorityQueue := &MinHeap{}
+	time := 0
+	average := 0
+	index := 0
+
+	for {
+		for j := index; j < len(jobs); j++ {
+      // time(ms) 시점까지 요청들어왔던 작업 확인 
+			if jobs[j][0] > time {
+				break
+			}
+
+			priorityQueue.Push(Job{jobs[j][0], jobs[j][1]})
+			index++
+		}
+    
+		if len(*priorityQueue) > 0 { // 처리해야할 작업이 있을 경우
+			job := priorityQueue.Pop()
+			time += job.burst
+			average = average + time - job.start
+		} else if index < len(jobs) { // 요청들어올 때까지 시간 경과
+			time++
+		} else {
+			break
+		}
+	}
+
+	return average / len(jobs)
+}


### PR DESCRIPTION
## 대략적인 풀이
- 본 문제는 작업의 우선순위를 다루고 있다. 한 번에 하나의 요청만을 수행할 수 있을 때, 
요청부터 종료까지 걸린 시간의 평균이 최소가 되도록 처리 순서를 구해야한다.
- 이 문제는 운영체제의 프로세스 스케줄링을 구현하는 것과 같다. 
프로세스 스케줄링 중에서 SPN (Shortest-Process-Next) 스케줄링과 같다.
핵심은 작업을 처리하는 시점에서 요청받은 작업들을 소요시간이 작은 순으로 정렬하는 것이다.
- 우선순위큐를 사용하는 것이 적절해 보이기 때문에,  min heap 을 구현하였다.
- 실행과정은 다음과 같다.
1. 요청시간이 작은 순으로 정렬하여 시간이 경과됨에 따라 `index`를 통해 `jobs[][]`를 탐색할 수 있게 만든다.
2. `time`값을 기준으로 `jobs[][]`를 탐색하며 해당 시점까지 요청이 들어온 작업들을 우선순위큐에 저장한다.
3. 우선순위큐에 저장된 작업들 중 소요시간이 최소인 작업을 바탕으로 시간 경과에 대한 처리를 하고, 
  해당 시간에서 작업의 요청이 들어온 시간을 뺀 전체 시간을 `average`에 더한다.
4. 만약 처리해야할 작업이 없지만 아직 모든 작업을 처리하지 않았다면,
  시간 경과를 나타내는 `time++`를 진행한다.
5. 모든 작업 처리까지 완료하였다면 반복문을 종료한다.
6. 각 작업의 총 걸린 시간의 합인 `average`를 작업의 개수로 나누면 구하고자 하는 값이 된다.

## 소요 메모리, 시간
- 4.3MB, 0.17ms