### PR TITLE
[Level 3] 42861 섬 연결하기

### DIFF
--- a/week07/assignment03/PROG_42861_HyeonjinChoi.go
+++ b/week07/assignment03/PROG_42861_HyeonjinChoi.go
@@ -1,0 +1,33 @@
+import "sort"
+
+func solution(n int, costs [][]int) int {
+    answer := 0
+	parentArr := make([]int, n)
+
+	for i := 0; i < n; i++ {
+		parentArr[i] = i
+	}
+
+	sort.Slice(costs, func(i, j int) bool {
+		return costs[i][2] < costs[j][2]
+	})
+
+	for i := 0; i < len(costs); i++ {
+		first, second := findParent(costs[i][0], parentArr), findParent(costs[i][1], parentArr)
+
+		if first != second {
+			answer += costs[i][2]
+			parentArr[second] = first
+		}
+	}
+
+	return answer
+}
+
+func findParent(node int, parentArr []int) int {
+	if parentArr[node] == node {
+		return node
+	} else {
+		return findParent(parentArr[node], parentArr)
+	}
+}


### PR DESCRIPTION
## 대략적인 풀이
- 본 문제는 비용에 대한 정렬과 연결된 노드들을 같은 집합으로 묶는 것이 핵심이었다.
- 우선 `costs[][]`를 비용이 작은 순으로 정렬한다.
- `first`와 `second`를 통해 연결할 노드들이 같은 집합인지 판별하여 연결한다.
- 연결될 때마다 최초에 자신의 노드가 저장되어있는 `parentArr[]`에 
인덱스가 작은 쪽의 부모 노드를 저장하였다.

## 소요 메모리, 시간
- 4.3MB, 0.01ms