### PR TITLE
[G1] 2213  트리의 독립집합

### DIFF
--- a/week08/assignment01/BOJ_2213_joonparkhere.go
+++ b/week08/assignment01/BOJ_2213_joonparkhere.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"sort"
+	"strconv"
+)
+
+var (
+	weights     []int
+	tree        []node
+	memoWeights []int
+	memoCases   []cases
+	elements    []int
+)
+
+type node struct {
+	parent   int
+	children []int
+}
+
+type cases bool
+const caseA cases = false	// 어떤 노드를 포함하지 않고 자식 노드들을 포함하는 경우
+const caseB cases = true	// 어떤 노드를 포함하고 자식 노드들을 포함하지 않는 경우
+
+func main() {
+	defer writer.Flush()
+	scanner.Split(bufio.ScanWords)
+
+	input()
+	solve()
+}
+
+func input() {
+	numOfNode := scanInt()
+
+	weights = make([]int, numOfNode+1)
+	for i := 1; i <= numOfNode; i++ {
+		weights[i] = scanInt()
+	}
+
+	graph := make([][]int, numOfNode+1)
+	for i := 0; i < numOfNode-1; i++ {
+		nodeA, nodeB := scanInt(), scanInt()
+		graph[nodeA] = append(graph[nodeA], nodeB)
+		graph[nodeB] = append(graph[nodeB], nodeA)
+	}
+
+	tree = make([]node, numOfNode+1)
+	initTree(graph, 0, 1)
+}
+
+func initTree(graph [][]int, parent, current int) {
+	for _, adjacent := range graph[current] {
+		if adjacent == parent {
+			tree[current].parent = adjacent
+			continue
+		}
+		initTree(graph, current, adjacent)
+		tree[current].children = append(tree[current].children, adjacent)
+	}
+}
+
+func solve() {
+	memoWeights = make([]int, len(tree))
+	memoCases = make([]cases, len(tree))
+	memoization(1)
+
+	elements = make([]int, 0)
+	findElements(1)
+	sort.Ints(elements)
+
+	writer.WriteString(strconv.Itoa(memoWeights[1]) + "\n")
+	for _, e := range elements {
+		writer.WriteString(strconv.Itoa(e) + " ")
+	}
+}
+
+func memoization(current int) {
+	for _, child := range tree[current].children {
+		memoization(child)
+	}
+
+	weightA, weightB := 0, weights[current]
+	for _, child := range tree[current].children {
+		weightA += memoWeights[child]
+
+		for _, grandchild := range tree[child].children {
+			weightB += memoWeights[grandchild]
+		}
+	}
+
+	if weightA >= weightB {
+		memoWeights[current] = weightA
+		memoCases[current] = caseA
+	} else {
+		memoWeights[current] = weightB
+		memoCases[current] = caseB
+	}
+}
+
+func findElements(current int) {
+	switch memoCases[current] {
+	case caseA:
+		for _, child := range tree[current].children {
+			findElements(child)
+		}
+	case caseB:
+		elements = append(elements, current)
+		for _, child := range tree[current].children {
+			for _, grandchild := range tree[child].children {
+				findElements(grandchild)
+			}
+		}
+	}
+}
+
+var (
+	scanner = bufio.NewScanner(os.Stdin)
+	writer = bufio.NewWriter(os.Stdout)
+)
+
+func scanInt() int {
+	scanner.Scan()
+	num := 0
+	for _, c := range scanner.Bytes() {
+		num = num * 10 + int(c - '0')
+	}
+	return num
+}


### PR DESCRIPTION
## 출처

[[BOJ] 2213  트리의 독립집합](https://www.acmicpc.net/problem/2213)



## 대략적인 풀이

- 트리를 구성하는 노드들에 대해서 직접적으로 인접하지 않는 노드들로만 구성된 부분 집합을 선별하는 문제이다.

- 가능한 부분 집합의 수는 상당히 많기 때문에 반복 작업이 예상되어 DP 개념을 사용했다. 다음과 같은 예시를 통해 살펴보자.

  ```
  [노드의 가중치]
   1  2  3  4  5  6  7
  10 40 40 20 20 20 70
  
  [트리 구조]
          5
        4
      3
  1 2
      6
        7
  ```

  부분 집합을 이룰 수 있는 경우는 두 가지가 있다.

  1. 현재 노드를 포함하지 않고, 자식 노드들을 포함하는 경우 - A Case
  2. 현재 노드를 포함하고, 자식 노드들을 포함하지 않는 경우 - B Case

  더불어서 트리 구조임을 고려해서, 하나의 큰 트리를 여러 개의 서브 트리로 생각하면 재귀 호출을 통해 구현할 수 있다. 위의 예시의 경우에 가중치의 합이 최댓값을 가질 수 있는 독립 집합은 아래와 같다.

  ```
  1 3 5 6 => 90
  1 3 5 7 => 140
  1 4 6 => 50
  1 4 7 => 100
  2 4 7 => 130
  2 5 7 => 130
  ```

  이처럼 부분 집합의 수가 많기 때문에 DP로 반복 작업을 생략해준다. 배열의 인덱스를 서브 트리의 루트 노드로 적용해 해당 서브 트리에서의 독립 집합 중 최대 가중치 합을 `memoWeights` 배열에 기록한다.

  추가로 문제에서는 독립 집합을 구성하는 노드들도 요구하고 있으므로 각 노드가 A, B 중 어느 경우에 속하는 지 `memoCases` 배열에 기록한다.

  재귀 호출로 모든 노드들을 훑으면 답을 구할 수 있다.

  

## 소요 메모리와 시간

1. DP 사용
   - 2692KB, 12ms

  

  