### PR TITLE
[G4] 1563 개근상

### DIFF
--- a/week09/assignment01/BOJ_1563_joonparkhere.java
+++ b/week09/assignment01/BOJ_1563_joonparkhere.java
@@ -1,0 +1,49 @@
+package assignment01;
+
+import java.io.*;
+
+public class BOJ_1563_joonparkhere {
+
+    static final int MOD = 1000000;
+    static int[][][] memo;  // [현재 일 수][지각 횟수][연속 결석 횟수]
+
+    public static void main(String[] args) throws IOException {
+        int days = Integer.parseInt(br.readLine());
+        memo = new int[days+1][2][3];
+
+        memoization(days);
+
+        int result = 0;
+        for (int lateness = 0; lateness < 2; lateness++)
+            for (int absence = 0; absence < 3; absence++)
+                result += memo[days][lateness][absence];
+        result %= MOD;
+
+        bw.append(String.valueOf(result));
+        bw.flush();
+        bw.close();
+    }
+
+    static void memoization(int day) {
+        memo[1][0][0] = 1;
+        memo[1][0][1] = 1;
+        memo[1][1][0] = 1;
+
+        for (int i = 2; i <= day; i++) {
+            memo[i][0][0] = memo[i-1][0][0] + memo[i-1][0][1] + memo[i-1][0][2];
+            memo[i][0][1] = memo[i-1][0][0];
+            memo[i][0][2] = memo[i-1][0][1];
+            memo[i][1][0] = memo[i-1][0][0] + memo[i-1][0][1] + memo[i-1][0][2] + memo[i-1][1][0] + memo[i-1][1][1] + memo[i-1][1][2];
+            memo[i][1][1] = memo[i-1][1][0];
+            memo[i][1][2] = memo[i-1][1][1];
+
+            for (int lateness = 0; lateness < 2; lateness++)
+                for (int absence = 0; absence < 3; absence++)
+                    memo[i][lateness][absence] %= MOD;
+        }
+    }
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+}


### PR DESCRIPTION
## 출처

[[BOJ] 1563 개근상](https://www.acmicpc.net/problem/1563)



## 대략적인 풀이

- 한 학기가 N일이라고 할 때, 해당 학기에서 개근상을 받을 수 있는 경우들을 구하기 위해서는 학기가 N-1일일 때 개근상을 받을 수 있는 경우들을 알아야 한다.

  즉, 이 말은 반복 작업이 생길 수 있고 점화식 형태로 표현 가능하다는 것이므로 DP를 사용하기에 적합한 문제이다.

- 다만 일반적인 DP는 2차원 배열 형태로 메모이제이션을 하는데, 이 문제의 경우 조건이 3가지 (날짜, 총 지각 횟수, 연속 결석 횟수) 라고 볼 수 있으므로 3차원 배열 형태로 수행한다.

  `k`일일 때 개근상을 받을 수 있는 경우들을 구한다고 한다면 아래와 같이 케이스를 나누어 구할 수 있다. 이때 주의할 점은 결석 일 수를 다룰 때는 연속인 경우에 유의해서 전날 결석했지만 오늘 출석했거나 지각했다면 연속 결석 횟수는 0으로 초기화 된다.

  - 총 지각 0번 && 연속 결석 0번

    => `k-1`일에서 "총 지각 0번 && 연속 결석 0번" + "총 지각 0번 && 연속 결석 1번" + "총 지각 0번 && 연속 결석 2번" 모두 더하면 구할 수 있다.

  - 총 지각 0번 && 연속 결석 1번

    => `k-1`일에서 "총 지각 0번 && 연속 결석 0번"

  - 총 지각 0번 && 연속 결석 2번

    => `k-1`일에서 "총 지각 0번 && 연속 결석 1번"

  - 총 지각 1번 && 연속 결석 0번

    => `k-1`일에서 "총 지각 0번 && 연속 결석 0번" + "총 지각 0번 && 연속 결석 1번" + "총 지각 0번 && 연속 결석 2번" + "총 지각 1번 && 연속 결석 0번" + "총 지각 1번 && 연속 결석 1번" + "총 지각 1번 && 연속 결석 2번" 모두 더하면 구할 수 있다.

  - 총 지각 1번 && 연속 결석 1번

    => `k-1`일에서 "총 지각 1번 && 연속 결석 0번"

  - 총 지각 1번 && 연속 결석 2번

    => `k-1`일에서 "총 지각 1번 && 연속 결석 1번"

  위의 과정을 메모이제이션을 통해 반복을 줄이며 표현하면 문제의 답을 구할 수 있다.



## 소요 메모리와 시간

1. 메모이제이션 적용

   - 14248KB, 128ms

     자바 언어 특성 상 메모리와 시간 소요가 크지만 다른 풀이와 비교 시 적당한 속도를 나타냄을 알 수 있다.