### PR TITLE
[G3] 1516 게임 개발

### DIFF
--- a/week09/assignment02/BOJ_1516_joonparkhere.java
+++ b/week09/assignment02/BOJ_1516_joonparkhere.java
@@ -1,0 +1,58 @@
+package assignment02;
+
+import java.io.*;
+
+public class BOJ_1516_joonparkhere {
+
+    static int[][] conditions;
+    static int[] costs;
+    static int[] completions;
+
+    public static void main(String[] args) throws IOException {
+        input();
+        solve();
+    }
+
+    static void input() throws IOException {
+        int numOfElement = Integer.parseInt(br.readLine());
+        conditions = new int[numOfElement + 1][];
+        costs = new int[numOfElement + 1];
+
+        for (int i = 1; i <= numOfElement; i++) {
+            String[] strings = br.readLine().split(" ");
+            costs[i] = Integer.parseInt(strings[0]);
+            conditions[i] = new int[strings.length - 2];
+            for (int j = 0; j < conditions[i].length; j++)
+                conditions[i][j] = Integer.parseInt(strings[j + 1]);
+        }
+    }
+
+    static void solve() throws IOException {
+        completions = new int[costs.length];
+        for (int building = 1; building < completions.length; building++) {
+            int completion = completions[building];
+            if (completion == 0)
+                completion = build(building);
+            bw.append(String.valueOf(completion)).append("\n");
+        }
+        bw.flush();
+        bw.close();
+    }
+
+    static int build(int building) {
+        int max = 0;
+        for (int condition : conditions[building]) {
+            int cur = completions[condition];
+            if (cur == 0)
+                cur = build(condition);
+            if (cur > max)
+                max = cur;
+        }
+        completions[building] = max + costs[building];
+        return completions[building];
+    }
+
+    static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+}


### PR DESCRIPTION
## 출처

[[BOJ] 1516 게임 개발](https://www.acmicpc.net/problem/1516)



## 대략적인 풀이

- 정해진 순서가 있는 각 요소에 대해서 작업을 완료할 수 있는 시간을 구하는 문제이다.

- 이전에 풀었던 [[BOJ] 2056 작업 PR](https://github.com/joonparkhere/algorithm-study/pull/24)과 사실상 동일한 문제라고 생각한다.

  다만 특정 요소를 수행하기 위한 선행 조건의 요소 번호가 더 클 수 있기 때문에 이를 위한 조건을 추가했다.

  각 요소마다 선행 조건들을 훑으며 해당 조건의 요소에 해당하는 작업이 완료됐는지 확인하고, 안됐으면 조건 요소에 대해 작업을 먼저 수행하도록 한다. 조건 요소에 해당하는 작업들이 모두 완료된 후에는 조건들의 작업 시간 중 최댓값을 구해서 현재 요소의 비용과 더한다.

  위 과정을 모든 요소에 대해 반복한다. 다만 불필요한 중복 작업을 피하기 위해 작업이 완료되지 않은 요소만 수행한다. 



## 소요 메모리와 시간

1. DP 적용

   - 21088KB, 212ms

     Java 11 언어에 한해 만족스러운 성능을 보여준다.