### PR TITLE
[G5] 2589 보물섬

### DIFF
--- a/week09/assignment03/BOJ_2589_joonparkhere.java
+++ b/week09/assignment03/BOJ_2589_joonparkhere.java
@@ -1,0 +1,86 @@
+package assignment03;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_2589_joonparkhere {
+
+    static final int[] dRow = {-1, 0, 1, 0};
+    static final int[] dCol = {0, -1, 0, 1};
+
+    static char[][] board;
+    static int maxCost;
+
+    static class Point {
+        int row;
+        int col;
+
+        public Point(int row, int col) {
+            this.row = row;
+            this.col = col;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        input();
+        solve();
+    }
+
+    static void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int rowSize = Integer.parseInt(st.nextToken());
+        int colSize = Integer.parseInt(st.nextToken());
+
+        board = new char[rowSize][colSize];
+        for (int row = 0; row < rowSize; row++) {
+            String input = br.readLine();
+            for (int col = 0; col < colSize; col++)
+                board[row][col] = input.charAt(col);
+        }
+    }
+
+    static void solve() throws IOException {
+        for (int row = 0; row < board.length; row++) {
+            for (int col = 0; col < board[0].length; col++) {
+                if (board[row][col] == 'W') continue;
+                bfs(new Point(row, col));
+            }
+        }
+
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        bw.append(String.valueOf(maxCost));
+        bw.flush();
+        bw.close();
+    }
+
+    static void bfs(Point start) {
+        Queue<Point> queue = new LinkedList<>();
+        queue.add(start);
+
+        int[][] cost = new int[board.length][board[0].length];
+        for (int row = 0; row < board.length; row++)
+            for (int col = 0; col < board[0].length; col++)
+                cost[row][col] = -1;
+        cost[start.row][start.col] = 0;
+
+        while (!queue.isEmpty()) {
+            Point current = queue.remove();
+
+            for (int i = 0; i < dRow.length; i++) {
+                int row = current.row + dRow[i];
+                int col = current.col + dCol[i];
+
+                if (row < 0 || row >= board.length || col < 0 || col >= board[0].length) continue;
+                if (board[row][col] == 'W' || cost[row][col] != -1) continue;
+
+                queue.add(new Point(row, col));
+                cost[row][col] = cost[current.row][current.col] + 1;
+                if (cost[row][col] > maxCost)
+                    maxCost = cost[row][col];
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## 출처

[[BOJ] 2589 보물섬](https://www.acmicpc.net/problem/2589)



## 대략적인 풀이

- 육지로 주어진 노드가 있고, 노드들이 인접한 상태에 따라서 해당 그래프에서 최단 거리로 가장 멀리 떨어진 거리를 구해야 한다.

  쉽게 그래프 탐색 문제임을 알 수 있고, 다만 고민을 많이 한 부분은 "탐색의 시작점과 끝점 어느 하나도 특정 지을 수 없을까"였다.

  떠오른 생각 중 하나는 트리의 지름 개념인데, 이전에 풀이한 문제에서 알 수 있었듯이 트리인 그래프에서는 그래프 탐색 2번을 하면 가장 멀리 떨어진 거리를 구할 수 있다.

  그렇다면 입력받은 그래프가 트리라 되도록 세팅해주는 작업이 필요하게 되는데, 이 부분에서 배보다 배꼽이 커질 것 같다는 생각에 그만 두었다.

- 결국 그냥 육지 상태인 모든 노드에 대해서 그래프 탐색을 해서 보물 사이의 거리를 구했다.



## 소요 메모리와 시간

1. 브루트 포스

   - 298068 KB, 536ms

     다른 Java 11 풀이의 결과를 보면 개선의 여지는 있지만, 그만큼의 효용이 없다고 생각해서 그만 두었다.