### PR TITLE
[Easy] 925 Long Pressed Name

### DIFF
--- a/week10/assignment01/LEET_925_joonparkhere.go
+++ b/week10/assignment01/LEET_925_joonparkhere.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+func isLongPressedName(name string, typed string) bool {
+	nameIdx, typedIdx := 0, 0
+	for {
+		if isBothEnd(name, typed, nameIdx, typedIdx) {
+			return true
+		}
+		if isOnlyOneEnd(name, typed, nameIdx, typedIdx) {
+			return false
+		}
+
+		nextNameIdx, nextTypedIdx := nextNonRepeatIndex(name, typed, nameIdx, typedIdx)
+		repeatName, repeatTyped := nextNameIdx - nameIdx + 1, nextTypedIdx - typedIdx + 1
+
+		if name[nextNameIdx] != typed[nextTypedIdx] {
+			return false
+		}
+		if repeatName > repeatTyped {
+			return false
+		}
+
+		nameIdx = nextNameIdx + 1
+		typedIdx = nextTypedIdx + 1
+	}
+}
+
+func isBothEnd(name, typed string, nameIdx, typedIdx int) bool {
+	if (nameIdx >= len(name)) && (typedIdx >= len(typed)) {
+		return true
+	}
+	return false
+}
+
+func isOnlyOneEnd(name, typed string, nameIdx, typedIdx int) bool {
+	if (nameIdx >= len(name)) && (typedIdx < len(typed)) {
+		return true
+	}
+	if (nameIdx < len(name)) && (typedIdx >= len(typed)) {
+		return true
+	}
+	return false
+}
+
+func nextNonRepeatIndex(name, typed string, nameIdx, typedIdx int) (int, int) {
+	for {
+		if (nameIdx + 1 >= len(name)) || (name[nameIdx] != name[nameIdx + 1]) {
+			break
+		}
+		nameIdx++
+	}
+	for {
+		if (typedIdx + 1 >= len(typed)) || (typed[typedIdx] != typed[typedIdx + 1]) {
+			break
+		}
+		typedIdx++
+	}
+	return nameIdx, typedIdx
+}
+
+func main() {
+	defer writer.Flush()
+	scanner.Scan()
+	inputName := scanner.Text()
+	scanner.Scan()
+	inputTyped := scanner.Text()
+	name := strings.Split(inputName, "\"")[1]
+	typed := strings.Split(inputTyped, "\"")[1]
+	if isLongPressedName(name, typed) {
+		writer.WriteString("True")
+	} else {
+		writer.WriteString("False")
+	}
+}
+
+var (
+	scanner = bufio.NewScanner(os.Stdin)
+	writer = bufio.NewWriter(os.Stdout)
+)


### PR DESCRIPTION
## 출처

[[LEET] 925 Long Pressed Name](https://leetcode.com/problems/long-pressed-name/)



## 대략적인 풀이

- 입력받은 두 문자열을 한 글자씩 훑으며 조건에 맞는지 확인하면 되는 간단한 문제이다.

- `typed`은 어떤 문자가 여러 번 눌릴 수 있는 문자열이므로, 동일한 문자임에 한해서 `name`에 속한 각 문자들의 수보다 `typed`에 속한 각 문자들의 수가 더 많거나 같아야 한다.

  이 점을 이용하여 두 문자열의 끝에 도달할 때까지 반복하면 답을 구할 수 있다.



## 소요 메모리와 시간

1. 단순 두 문자열 비교

   - 2 MB, 0 ms

     메모리와 시간 모두 알맞은 소요 결과를 보여준다.