### PR TITLE
[G4] 16197 두 동전

### DIFF
--- a/week10/assignment03/BOJ_16197_joonparkhere.java
+++ b/week10/assignment03/BOJ_16197_joonparkhere.java
@@ -1,0 +1,131 @@
+package assignment03;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_16197_joonparkhere {
+
+    static class Coin {
+        int row;
+        int col;
+
+        Coin(int row, int col) {
+            this.row = row;
+            this.col = col;
+        }
+
+        boolean canMove() {
+            if (row >= 0 && row < rowSize && col >= 0 && col < colSize && board[row][col] == -1)
+                return false;
+            return true;
+        }
+
+        boolean isDropped() {
+            if (row >= 0 && row < rowSize && col >= 0 && col < colSize)
+                return false;
+            return true;
+        }
+    }
+
+    static class Element {
+        int count;
+        List<Coin> coinList;
+
+        public Element(int count, List<Coin> coinList) {
+            this.count = count;
+            this.coinList = coinList;
+        }
+    }
+
+    static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static final int MAX_COUNT = 10;
+    static final int DIRECTION_NUM = 4;
+    static final int[] dRow = {-1, 0, 1, 0};
+    static final int[] dCol = {0, 1, 0, -1};
+
+    static int rowSize;
+    static int colSize;
+    static int[][] board;
+    static List<Coin> initCoinList = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        init();
+        solve();
+    }
+    
+    static void init() throws IOException {
+        String[] inputStr = br.readLine().split(" ");
+        rowSize = Integer.parseInt(inputStr[0]);
+        colSize = Integer.parseInt(inputStr[1]);
+        board = new int[rowSize][colSize];
+
+        for (int row = 0; row < rowSize; row++) {
+            String states = br.readLine();
+            for (int col = 0; col < colSize; col++) {
+                switch (states.charAt(col)) {
+                    case 'o':
+                        initCoinList.add(new Coin(row, col));
+                    case '.':
+                        board[row][col] = 1;
+                        break;
+                    case '#':
+                        board[row][col] = -1;
+                        break;
+                }
+            }
+        }
+    }
+
+    static void solve() throws IOException {
+        boolean[][][][] isVisit = new boolean[rowSize][colSize][rowSize][colSize];
+        isVisit[initCoinList.get(0).row][initCoinList.get(0).col][initCoinList.get(1).row][initCoinList.get(1).col] = true;
+
+        Queue<Element> queue = new LinkedList<>();
+        queue.add(new Element(0, initCoinList));
+
+        while (!queue.isEmpty()) {
+            Element current = queue.remove();
+
+            if (current.count >= MAX_COUNT) break;
+
+            for (int direction = 0; direction < DIRECTION_NUM; direction++) {
+                List<Coin> nextCoinList = new ArrayList<>();
+                int droppedCount = 0;
+
+                for (Coin coin : current.coinList) {
+                    int nextRow = coin.row + dRow[direction];
+                    int nextCol = coin.col + dCol[direction];
+                    Coin nextCoin = new Coin(nextRow, nextCol);
+
+                    if (!nextCoin.canMove()) {
+                        nextCoin.row = coin.row;
+                        nextCoin.col = coin.col;
+                    }
+                    if (nextCoin.isDropped())
+                        droppedCount++;
+
+                    nextCoinList.add(nextCoin);
+                }
+
+                if (droppedCount == 1) {
+                    bw.append(String.valueOf(current.count + 1));
+                    bw.flush();
+                    bw.close();
+                    return;
+                }
+                if (droppedCount == 0) {
+                    if (!isVisit[nextCoinList.get(0).row][nextCoinList.get(0).col][nextCoinList.get(1).row][nextCoinList.get(1).col]) {
+                        isVisit[nextCoinList.get(0).row][nextCoinList.get(0).col][nextCoinList.get(1).row][nextCoinList.get(1).col] = true;
+                        queue.add(new Element(current.count + 1, nextCoinList));
+                    }
+                }
+            }
+        }
+
+        bw.append("-1");
+        bw.flush();
+        bw.close();
+    }
+
+}


### PR DESCRIPTION
## 출처

[[BOJ] 16197 두 동전](https://www.acmicpc.net/problem/16197)



## 대략적인 풀이

- 문제 풀이의 핵심은 그래프 탐색의 활용이 가능하냐 이것이다.

  보통 DFS / BFS 는 탐색할 때 하나의 대상만으로 그래프 탐색을 하는데, 이 문제의 경우 두 개의 대상을 동시에 탐색을 한다.

  그리고 이 문제는 가장 먼저 두 대상 중 하나만이 살아남은 경우를 찾아야 하므로, DFS 보다는 BFS를 이용하면 더 빠르게 찾을 수 있다.

  따라서 일반적인 BFS 구현 방법에 Queue에 들어가는 대상이 코인 두 개의 정보이어야 한다.

  그리고 보통 방문 여부를 기록하기 위해 `boolean[][] isVisit`와 같은 2차원 배열을 사용하는데, 대상이 두 개임을 고려해서 4차원 배열을 사용해야 한다.

  위의 두 가지를 조심하며 문제에서 요구한 조건들에 맞게 조건문을 중간 중간 짜놓으면 해결할 수 있다.



## 소요 메모리와 시간

1. BFS 형태로 구현했으나, 처음에는 방문 여부를 기록하지 않고 Brute-Force 방식으로 모든 가능한 경로들을 훑었다. 그러다 보니 메모리와 시간의 소요가 매우 컸다.
   - 513832 KB, 900 ms
2. 이후 4차원 배열 꼴 변수로 방문 여부를 기록하여 제대로 된 BFS를 구현했다.
   - 14596 KB, 136 ms