### PR TITLE
[G1] 12837 가계부

### DIFF
--- a/week11/assignment01/BOJ_12837_joonparkhere.go
+++ b/week11/assignment01/BOJ_12837_joonparkhere.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bufio"
+	"math"
+	"os"
+	"strconv"
+)
+
+var (
+	dayNum int
+	queryNum int
+	tree []int
+)
+
+func main() {
+	defer writer.Flush()
+
+	setUp()
+	solve()
+}
+
+func setUp() {
+	inputArr := scanIntArr()
+	dayNum, queryNum = inputArr[0], inputArr[1]
+
+	treeSize := int(math.Pow(2, math.Ceil(math.Log2(float64(dayNum))) + 1))
+	tree = make([]int, treeSize)
+}
+
+func solve() {
+	for i := 0; i < queryNum; i++ {
+		query := scanIntArr()
+		switch query[0] {
+		case 1:
+			update(query[1], query[2])
+			break
+		case 2:
+			result := find(query[1], query[2])
+			writer.WriteString(strconv.Itoa(result) + "\n")
+			break
+		}
+	}
+}
+
+func update(target, value int) {
+	idx := len(tree) / 2 + target - 1
+	for idx >= 1 {
+		tree[idx] += value
+		idx /= 2
+	}
+}
+
+func find(left, right int) int {
+	sum := 0
+	idxL, idxR := len(tree) / 2 + left - 1, len(tree) / 2 + right - 1
+	for idxL < idxR {
+		if idxL & 1 == 1 {
+			sum += tree[idxL]
+			idxL++
+		}
+		if idxR & 1 == 0 {
+			sum += tree[idxR]
+			idxR--
+		}
+
+		idxL /= 2
+		idxR /= 2
+	}
+	if idxL == idxR {
+		sum += tree[idxL]
+	}
+
+	return sum
+}
+
+var (
+	scanner = bufio.NewScanner(os.Stdin)
+	writer = bufio.NewWriter(os.Stdout)
+)
+
+func scanIntArr() []int {
+	scanner.Scan()
+	arr := make([]int, 1)
+	idx := 0
+	mark := 1
+	for _, c := range scanner.Bytes() {
+		if c == ' ' {
+			arr = append(arr, 0)
+			idx++
+			continue
+		}
+		if c == '-' {
+			mark = -1
+			continue
+		}
+		arr[idx] = arr[idx] * 10 + mark * int(c - '0')
+	}
+	return arr
+}


### PR DESCRIPTION
## 출처

[[BOJ] 12837 가계부](https://www.acmicpc.net/problem/12837)



## 대략적인 풀이

- 전형적인 세그먼트 트리 구현 문제이다.

- 세그먼트 트리 구현시, Top-Bottom과 Bottom-Top 두 가지 방식이 있는데, 반복문을 이용하는 Bottom-Top 방식으로 구현했다.

- 문제에서 `1 p x` 혹은 `2 p q` 쿼리가 들어온다.

  우선 1번 쿼리인 데이터 업데이트 쿼리의 경우, `p`번째 데이터를 가리키는 트리 idx (Leaf Node)를 시점으로 루트 노드까지 `x`만큼 값을 더하면 된다.

  그리고 2번 쿼리인 구간 합 쿼리의 경우, 구간 시작을 의미하는 `p`번째 데이터를 가리키는 트리 idxL (Leaf Node)와 구간 끝을 의미하는 `q`번째 데이터를 가리키는 트리 idxR (Leaf Node)를 시점으로 루트 노드까지 값을 다 더하면 된다.

  이때 주의해야 할 점은 만약 `p`가 4번째 데이터를 가리키고 있다면, idxL의 부모 노드는 3~4 구간의 누적 합이지만 우리는 3 구간은 필요가 없기 때문에 부모 노드로 올라갈 필요가 없다. 따라서 idxL의 누적 합을 저장하고 idxL+1 연산을 해서 다음 데이터인 5번째 데이터를 가리키게 만든다. `q`의 경우도 마찬가지인데, 구간의 끝을 의미하므로 idxR-1 연산을 해야한다.



## 소요 메모리와 시간

1. 세그먼트 트리 활용
   - 27780 KB, 80ms