### PR TITLE
[G1] 12837 가계부

### DIFF
--- a/week11/assignment01/BOJ_12837_HyeonjinChoi.go
+++ b/week11/assignment01/BOJ_12837_HyeonjinChoi.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bufio"
+	"math"
+	"os"
+	"strconv"
+)
+
+var (
+	sc         *bufio.Scanner
+	wr         *bufio.Writer
+	daysLived  int
+	numOfQuery int
+	tree       []int
+)
+
+func init() {
+	sc = bufio.NewScanner(os.Stdin)
+	sc.Split(bufio.ScanWords)
+	wr = bufio.NewWriter(os.Stdout)
+}
+
+func scanInt() int {
+	sc.Scan()
+	num, _ := strconv.Atoi(sc.Text())
+	return num
+}
+
+func main() {
+	defer wr.Flush()
+	setting()
+	solve()
+}
+
+func setting() {
+	daysLived, numOfQuery = scanInt(), scanInt()
+	tree = make([]int, int(math.Pow(2, math.Ceil(math.Log2(float64(daysLived)))+1)))
+}
+
+func solve() {
+	for i := 0; i < numOfQuery; i++ {
+		separatorNum, days, price := scanInt(), scanInt(), scanInt()
+
+		if separatorNum == 1 {
+			update(1, 1, daysLived, days, price)
+		} else {
+			wr.WriteString(strconv.Itoa(query(1, 1, daysLived, days, price)) + "\n")
+		}
+	}
+}
+
+func update(node, start, end, index, value int) {
+	if start == end {
+		tree[node] += value
+		return
+	}
+
+	mid := (start + end) / 2
+
+	if index <= mid {
+		update(2*node, start, mid, index, value)
+	} else {
+		update(2*node+1, mid+1, end, index, value)
+	}
+
+	tree[node] = tree[2*node] + tree[2*node+1]
+}
+
+func query(node, start, end, queryStart, queryEnd int) int {
+	if queryStart > end || queryEnd < start {
+		return 0
+	}
+
+	if queryStart <= start && end <= queryEnd {
+		return tree[node]
+	}
+
+	mid := (start + end) / 2
+
+	return query(2*node, start, mid, queryStart, queryEnd) + query(2*node+1, mid+1, end, queryStart, queryEnd)
+}

--- a/week11/assignment01/BOJ_12837_HyeonjinChoi.go
+++ b/week11/assignment01/BOJ_12837_HyeonjinChoi.go
@@ -40,12 +40,12 @@ func setting() {
 
 func solve() {
 	for i := 0; i < numOfQuery; i++ {
-		separatorNum, days, price := scanInt(), scanInt(), scanInt()
+		separatorNum, day, priceOrDay := scanInt(), scanInt(), scanInt()
 
 		if separatorNum == 1 {
-			update(1, 1, daysLived, days, price)
+			update(1, 1, daysLived, day, priceOrDay)
 		} else {
-			wr.WriteString(strconv.Itoa(query(1, 1, daysLived, days, price)) + "\n")
+			wr.WriteString(strconv.Itoa(query(1, 1, daysLived, day, priceOrDay)) + "\n")
 		}
 	}
 }
@@ -56,15 +56,15 @@ func update(node, start, end, index, value int) {
 		return
 	}
 
-	mid := (start + end) / 2
+	mid := (start + end) >> 1
 
 	if index <= mid {
-		update(2*node, start, mid, index, value)
+		update(node<<1, start, mid, index, value)
 	} else {
-		update(2*node+1, mid+1, end, index, value)
+		update((node<<1)+1, mid+1, end, index, value)
 	}
 
-	tree[node] = tree[2*node] + tree[2*node+1]
+	tree[node] = tree[node<<1] + tree[(node<<1)+1]
 }
 
 func query(node, start, end, queryStart, queryEnd int) int {
@@ -76,7 +76,7 @@ func query(node, start, end, queryStart, queryEnd int) int {
 		return tree[node]
 	}
 
-	mid := (start + end) / 2
+	mid := (start + end) >> 1
 
-	return query(2*node, start, mid, queryStart, queryEnd) + query(2*node+1, mid+1, end, queryStart, queryEnd)
+	return query(node<<1, start, mid, queryStart, queryEnd) + query((node<<1)+1, mid+1, end, queryStart, queryEnd)
 }


### PR DESCRIPTION
## 대략적인 풀이
- 세그먼트 트리를 이용하면 쉽게 풀 수 있는 문제였다.
- 쿼리는 두 종류가 있다.
하나는 생후 `p`일에 수입/지출 내용을 추가하는 것.
다른 하나는 생후 `p`일부터 `q`일까지 잔고가 변화한 값을 출력하는 것.
- 첫번째 경우는 주어진 수입/지출 값에 대한 `update()`를 진행한다.
일반적인 세그먼트 트리와 같이 살아온 날에 대한 구간합을 노드들에 갱신한다.
- 두번째 경우는 `p`일부터 `q`일까지에 대한 `query()`를 진행한다.
간단하게 주어진 범위에 대한 구간합을 구하면 된다.

## 소요 메모리, 시간
- 첫번째 시도 : 24516KB, 108ms
  - 일반적인 풀이를 진행했다.
- 두번째 시도 : 24500KB, 88ms
  - 첫번째 시도에서 거의 바뀐 것은 없고 노드에 대한 연산을 진행할 때,
  `mid := (start + end) >> 1` 또는 `tree[node] = tree[node<<1] + tree[(node<<1)+1]`와 같이
  모두 비트연산으로 바꿔주었는데, 소폭의 시간 단축을 확인해볼 수 있었다.