### PR TITLE
[G4] 2239 스도쿠

### DIFF
--- a/week13/assignment01/BOJ_2239_joonparkhere.java
+++ b/week13/assignment01/BOJ_2239_joonparkhere.java
@@ -11,20 +11,13 @@ public class BOJ_2239_joonparkhere {
 
     static int[][] board = new int[SUDOKU_SIZE][SUDOKU_SIZE];
     static List<int[]> candidateList = new ArrayList<>();
-    static boolean[][] isBlockExist = new boolean[SUDOKU_SIZE][SUDOKU_SIZE + 1];
-    static boolean[][] isRowExist = new boolean[SUDOKU_SIZE][SUDOKU_SIZE + 1];
-    static boolean[][] isColExist = new boolean[SUDOKU_SIZE][SUDOKU_SIZE + 1];
+    static int[] isRowExist = new int[SUDOKU_SIZE];
+    static int[] isColExist = new int[SUDOKU_SIZE];
+    static int[] isBlockExist = new int[SUDOKU_SIZE];
 
     public static void main(String[] args) throws IOException {
         init();
         check(0);
-    }
-
-    private static void updateExist(int row, int col, int value) {
-        int blockIdx = 3 * (row / 3) + (col / 3);
-        isBlockExist[blockIdx][value] = !isBlockExist[blockIdx][value];
-        isRowExist[row][value] = !isRowExist[row][value];
-        isColExist[col][value] = !isColExist[col][value];
     }
 
     static void init() throws IOException {
@@ -32,13 +25,15 @@ public class BOJ_2239_joonparkhere {
             String inputStr = br.readLine();
 
             for (int col = 0; col < SUDOKU_SIZE; col++) {
-                int value = inputStr.charAt(col) - '0';
-                board[row][col] = value;
+                board[row][col] = inputStr.charAt(col) - '0';
 
-                if (value == 0) {
+                if (board[row][col] == 0) {
                     candidateList.add(new int[]{row, col});
                 } else {
-                    updateExist(row, col, value);
+                    int digit = 1 << board[row][col];
+                    isRowExist[row] |= digit;
+                    isColExist[col] |= digit;
+                    isBlockExist[3 * (row / 3) + (col / 3)] |= digit;
                 }
             }
         }
@@ -50,33 +45,28 @@ public class BOJ_2239_joonparkhere {
             System.exit(0);
         }
 
-        int[] candidate = candidateList.get(idx);
-        int row = candidate[0], col = candidate[1];
+        int row = candidateList.get(idx)[0];
+        int col = candidateList.get(idx)[1];
+        int curDigit = isRowExist[row] | isColExist[col] | isBlockExist[3 * (row / 3) + (col / 3)];
 
         for (int value = 1; value <= SUDOKU_SIZE; value++) {
-            if (!isValid(row, col, value))
+            int nextDigit = 1 << value;
+
+            if ((curDigit & nextDigit) != 0)
                 continue;
 
-            updateExist(row, col, value);
             board[row][col] = value;
+            isRowExist[row] |= nextDigit;
+            isColExist[col] |= nextDigit;
+            isBlockExist[3 * (row / 3) + (col / 3)] |= nextDigit;
 
             check(idx + 1);
 
-            updateExist(row, col, value);
             board[row][col] = 0;
+            isRowExist[row] &= ~nextDigit;
+            isColExist[col] &= ~nextDigit;
+            isBlockExist[3 * (row / 3) + (col / 3)] &= ~nextDigit;
         }
-    }
-
-    private static boolean isValid(int row, int col, int value) {
-        int blockIdx = 3 * (row / 3) + (col / 3);
-        if (isBlockExist[blockIdx][value])
-            return false;
-        if (isRowExist[row][value])
-            return false;
-        if (isColExist[col][value])
-            return false;
-
-        return true;
     }
 
     private static void print() throws IOException {

--- a/week13/assignment01/BOJ_2239_joonparkhere.java
+++ b/week13/assignment01/BOJ_2239_joonparkhere.java
@@ -1,95 +1,88 @@
 package assignment01;
 
 import java.io.*;
+import java.util.*;
 
 public class BOJ_2239_joonparkhere {
 
     static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
     static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static final int SUDOKU_SIZE = 9;
 
-    static int[][] board = new int[9][9];
-    static boolean[][] isRowExist = new boolean[9][10];
-    static boolean[][] isColExist = new boolean[9][10];
-    static boolean[][] isBlockExist = new boolean[9][10];
+    static int[][] board = new int[SUDOKU_SIZE][SUDOKU_SIZE];
+    static List<int[]> candidateList = new ArrayList<>();
+    static boolean[][] isBlockExist = new boolean[SUDOKU_SIZE][SUDOKU_SIZE + 1];
+    static boolean[][] isRowExist = new boolean[SUDOKU_SIZE][SUDOKU_SIZE + 1];
+    static boolean[][] isColExist = new boolean[SUDOKU_SIZE][SUDOKU_SIZE + 1];
 
     public static void main(String[] args) throws IOException {
         init();
         check(0);
     }
 
+    private static void updateExist(int row, int col, int value) {
+        int blockIdx = 3 * (row / 3) + (col / 3);
+        isBlockExist[blockIdx][value] = !isBlockExist[blockIdx][value];
+        isRowExist[row][value] = !isRowExist[row][value];
+        isColExist[col][value] = !isColExist[col][value];
+    }
+
     static void init() throws IOException {
-        int cur = 0;
-        for (int i = 0; i < 9; i++) {
+        for (int row = 0; row < SUDOKU_SIZE; row++) {
             String inputStr = br.readLine();
 
-            for (char c : inputStr.toCharArray()) {
-                int row = cur / 9;
-                int col = cur % 9;
+            for (int col = 0; col < SUDOKU_SIZE; col++) {
+                int value = inputStr.charAt(col) - '0';
+                board[row][col] = value;
 
-                int num = c - '0';
-                board[row][col] = num;
-                if (num != 0) {
-                    isRowExist[row][num] = true;
-                    isColExist[col][num] = true;
-                    isBlockExist[3 * (row / 3) + (col / 3)][num] = true;
+                if (value == 0) {
+                    candidateList.add(new int[]{row, col});
+                } else {
+                    updateExist(row, col, value);
                 }
-
-                cur++;
             }
         }
     }
 
-    static void check(int cur) throws IOException {
-        if (cur == 81) {
+    static void check(int idx) throws IOException {
+        if (idx == candidateList.size()) {
             print();
             System.exit(0);
         }
 
-        int row = cur / 9;
-        int col = cur % 9;
+        int[] candidate = candidateList.get(idx);
+        int row = candidate[0], col = candidate[1];
 
-        if (board[row][col] != 0) {
-            check(cur + 1);
-            return;
-        }
-
-        for (int num = 1; num <= 9; num++) {
-            if (!isValid(cur, num))
+        for (int value = 1; value <= SUDOKU_SIZE; value++) {
+            if (!isValid(row, col, value))
                 continue;
 
-            isRowExist[row][num] = true;
-            isColExist[col][num] = true;
-            isBlockExist[3 * (row / 3) + (col / 3)][num] = true;
-            board[row][col] = num;
+            updateExist(row, col, value);
+            board[row][col] = value;
 
-            check(cur + 1);
+            check(idx + 1);
 
-            isRowExist[row][num] = false;
-            isColExist[col][num] = false;
-            isBlockExist[3 * (row / 3) + (col / 3)][num] = false;
+            updateExist(row, col, value);
             board[row][col] = 0;
         }
     }
 
-    private static boolean isValid(int cur, int num) {
-        int row = cur / 9;
-        int col = cur % 9;
-
-        if (isRowExist[row][num])
+    private static boolean isValid(int row, int col, int value) {
+        int blockIdx = 3 * (row / 3) + (col / 3);
+        if (isBlockExist[blockIdx][value])
             return false;
-        if (isColExist[col][num])
+        if (isRowExist[row][value])
             return false;
-        if (isBlockExist[3 * (row / 3) + (col / 3)][num])
+        if (isColExist[col][value])
             return false;
 
         return true;
     }
 
     private static void print() throws IOException {
-        for (int row = 0; row < 9; row++) {
-            for (int col = 0; col < 9; col++) {
+        for (int row = 0; row < SUDOKU_SIZE; row++) {
+            for (int col = 0; col < SUDOKU_SIZE; col++)
                 bw.append(String.valueOf(board[row][col]));
-            }
             bw.newLine();
         }
 

--- a/week13/assignment01/BOJ_2239_joonparkhere.java
+++ b/week13/assignment01/BOJ_2239_joonparkhere.java
@@ -1,0 +1,100 @@
+package assignment01;
+
+import java.io.*;
+
+public class BOJ_2239_joonparkhere {
+
+    static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    static int[][] board = new int[9][9];
+    static boolean[][] isRowExist = new boolean[9][10];
+    static boolean[][] isColExist = new boolean[9][10];
+    static boolean[][] isBlockExist = new boolean[9][10];
+
+    public static void main(String[] args) throws IOException {
+        init();
+        check(0);
+    }
+
+    static void init() throws IOException {
+        int cur = 0;
+        for (int i = 0; i < 9; i++) {
+            String inputStr = br.readLine();
+
+            for (char c : inputStr.toCharArray()) {
+                int row = cur / 9;
+                int col = cur % 9;
+
+                int num = c - '0';
+                board[row][col] = num;
+                if (num != 0) {
+                    isRowExist[row][num] = true;
+                    isColExist[col][num] = true;
+                    isBlockExist[3 * (row / 3) + (col / 3)][num] = true;
+                }
+
+                cur++;
+            }
+        }
+    }
+
+    static void check(int cur) throws IOException {
+        if (cur == 81) {
+            print();
+            System.exit(0);
+        }
+
+        int row = cur / 9;
+        int col = cur % 9;
+
+        if (board[row][col] != 0) {
+            check(cur + 1);
+            return;
+        }
+
+        for (int num = 1; num <= 9; num++) {
+            if (!isValid(cur, num))
+                continue;
+
+            isRowExist[row][num] = true;
+            isColExist[col][num] = true;
+            isBlockExist[3 * (row / 3) + (col / 3)][num] = true;
+            board[row][col] = num;
+
+            check(cur + 1);
+
+            isRowExist[row][num] = false;
+            isColExist[col][num] = false;
+            isBlockExist[3 * (row / 3) + (col / 3)][num] = false;
+            board[row][col] = 0;
+        }
+    }
+
+    private static boolean isValid(int cur, int num) {
+        int row = cur / 9;
+        int col = cur % 9;
+
+        if (isRowExist[row][num])
+            return false;
+        if (isColExist[col][num])
+            return false;
+        if (isBlockExist[3 * (row / 3) + (col / 3)][num])
+            return false;
+
+        return true;
+    }
+
+    private static void print() throws IOException {
+        for (int row = 0; row < 9; row++) {
+            for (int col = 0; col < 9; col++) {
+                bw.append(String.valueOf(board[row][col]));
+            }
+            bw.newLine();
+        }
+
+        bw.flush();
+        bw.close();
+    }
+
+}


### PR DESCRIPTION
## 출처

[[BOJ] 2239 스도쿠](https://www.acmicpc.net/problem/2239)



## 대략적인 풀이

- 백트래킹을 타겟으로 하는 문제이다.
- 맨 앞의 빈 칸부터 시작해서 작은 숫자부터 하나씩 넣어보며 스도쿠 규칙을 지킬 때까지 다음 칸으로 이동해 동일한 과정을 반복한다.
- 반복 중 스도쿠 규칙이 어긋나는 순간, 이전 칸으로 돌아가서 하나 더 큰 숫자로 변경 후 다시 반복을 진행한다.
- 위 과정이 백트래킹이며, 재귀 호출로써 구현했다.
- 더불어 처음에는 스도쿠 모든 칸을 훑으며 빈 칸인지 아닌지에 따라 재귀 호출 여부를 결정 했는데, 처음 입력 받을 때 빈칸의 위치를 별도로 저장해서 불필요한 반복 횟수를 줄이도록 수정했다.
- 추가로 각 칸이 빈 칸인지 아닌지 판단하기 위한 배열을 boolean 형태에서 bit operation을 활용한 int 형태로 변경했다.



## 소요 메모리와 시간

1. bit operation 적용 전
   - 18964 KB, 440 ms
2. bit operation 적용 후
   - 18216 KB, 348 ms